### PR TITLE
NV6487: Scanner: implement wipe-out attributes during reconstructing image repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/aws/aws-sdk-go v1.42.36 // indirect
 	github.com/docker/docker v20.10.12+incompatible // indirect
 	github.com/google/uuid v1.3.0
-	github.com/neuvector/neuvector v0.0.0-20220504163316-fb7541f75c2c
+	github.com/neuvector/neuvector v0.0.0-20220616012106-847c3fced01c
 	github.com/sirupsen/logrus v1.8.1
 	google.golang.org/grpc v1.40.0
 )

--- a/go.sum
+++ b/go.sum
@@ -696,8 +696,8 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20160627004424-a22cb81b2ecd/go.mod h1:o96d
 github.com/nbutton23/zxcvbn-go v0.0.0-20171102151520-eafdab6b0663/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/neuvector/k8s v1.2.1-0.20220214174348-d0b3f377461e h1:y7w21QaxlBzeRNW1PEdBfR/rA0S801uCEvubsiq1AJ0=
 github.com/neuvector/k8s v1.2.1-0.20220214174348-d0b3f377461e/go.mod h1:djxl7Js+tfAJJgxKpeN3lnFZT6jRhl1Ikkgd/wMrLQU=
-github.com/neuvector/neuvector v0.0.0-20220504163316-fb7541f75c2c h1:OauJ3/QONI22LJRCi7f+NdCplJU7hFEx5WFKdyViOeM=
-github.com/neuvector/neuvector v0.0.0-20220504163316-fb7541f75c2c/go.mod h1:VqqrTb5QcBkdsh+SP00/tBbfg+PA5DAGjaiYkrzj+xg=
+github.com/neuvector/neuvector v0.0.0-20220616012106-847c3fced01c h1:MVSNDYFPZGO5iMOwa4SJZW5ig0TtqlpTROJy4xcFZOo=
+github.com/neuvector/neuvector v0.0.0-20220616012106-847c3fced01c/go.mod h1:VqqrTb5QcBkdsh+SP00/tBbfg+PA5DAGjaiYkrzj+xg=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/vendor/github.com/neuvector/neuvector/controller/api/apis.go
+++ b/vendor/github.com/neuvector/neuvector/controller/api/apis.go
@@ -167,9 +167,9 @@ const (
 )
 
 const (
-	BenchCatalogDocker = "docker"
-	BenchCatalogKube   = "kubernetes"
-	BenchCatalogCustom = "custom"
+	BenchCategoryDocker = "docker"
+	BenchCategoryKube   = "kubernetes"
+	BenchCategoryCustom = "custom"
 
 	BenchTypeMaster    = "master"
 	BenchTypeWorker    = "worker"
@@ -549,9 +549,11 @@ type RESTUserData struct {
 }
 
 type RESTSelfUserData struct {
-	User                *RESTUser `json:"user"`
-	PwdDaysUntilExpire  int       `json:"password_days_until_expire"`  // negative means password never expires
-	PwdHoursUntilExpire int       `json:"password_hours_until_expire"` // the hours part beyond PwdDaysUntilExpire, 0 ~ 23
+	User                *RESTUser                        `json:"user"`
+	PwdDaysUntilExpire  int                              `json:"password_days_until_expire"`  // negative means password never expires
+	PwdHoursUntilExpire int                              `json:"password_hours_until_expire"` // the hours part beyond PwdDaysUntilExpire, 0 ~ 23
+	GlobalPermits       []*RESTRolePermission            `json:"global_permissions,omitempty"`
+	DomainPermits       map[string][]*RESTRolePermission `json:"domain_permissions,omitempty"` // domain -> permissions
 }
 
 type RESTUserConfigData struct {
@@ -691,6 +693,7 @@ type RESTHost struct {
 	Memory            int64                    `json:"memory"`
 	CGroupVersion     int                      `json:"cgroup_version"`
 	Containers        int                      `json:"containers"`
+	Pods              int                      `json:"pods"`
 	Ifaces            map[string][]*RESTIPAddr `json:"interfaces"`
 	State             string                   `json:"state"`
 	CapDockerBench    bool                     `json:"cap_docker_bench"`
@@ -2246,7 +2249,7 @@ type RESTWorkloadInterceptData struct {
 
 type RESTBenchCheck struct {
 	TestNum     string   `json:"test_number"`
-	Catalog     string   `json:"catalog"`
+	Category    string   `json:"category"`
 	Type        string   `json:"type"`
 	Profile     string   `json:"profile"`
 	Scored      bool     `json:"scored"`
@@ -2279,7 +2282,6 @@ type RESTBenchReport struct {
 type RESTComplianceData struct {
 	RunAtTimeStamp int64            `json:"run_timestamp"`
 	RunAt          string           `json:"run_at"`
-	KubeCategory   string           `json:"kubernetes_cis_category"`
 	KubeVersion    string           `json:"kubernetes_cis_version"`
 	DockerVersion  string           `json:"docker_cis_version"`
 	Items          []*RESTBenchItem `json:"items"`
@@ -2287,7 +2289,7 @@ type RESTComplianceData struct {
 
 type RESTComplianceAsset struct {
 	Name        string   `json:"name"`
-	Catalog     string   `json:"catalog"`
+	Category    string   `json:"category"`
 	Type        string   `json:"type"`
 	Level       string   `json:"level"`
 	Profile     string   `json:"profile"`
@@ -2309,7 +2311,6 @@ type RESTComplianceAssetData struct {
 	Nodes         map[string][]RESTIDName `json:"nodes"`
 	Images        map[string][]RESTIDName `json:"images"`
 	Platforms     map[string][]RESTIDName `json:"platforms"`
-	KubeCategory  string                  `json:"kubernetes_cis_category"`
 	KubeVersion   string                  `json:"kubernetes_cis_version"`
 	DockerVersion string                  `json:"docker_cis_version"`
 }

--- a/vendor/github.com/neuvector/neuvector/share/cluster/grpc.go
+++ b/vendor/github.com/neuvector/neuvector/share/cluster/grpc.go
@@ -16,7 +16,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/peer"
 
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/utils"
@@ -28,13 +27,15 @@ var subjectCN string
 
 func middlefunc(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 	// get client tls info
-	if p, ok := peer.FromContext(ctx); ok {
-		if mtls, ok := p.AuthInfo.(credentials.TLSInfo); ok {
-			for _, item := range mtls.State.PeerCertificates {
-				log.WithFields(log.Fields{"subject": item.Subject}).Info("grpc cert")
+	/*
+		if p, ok := peer.FromContext(ctx); ok {
+			if mtls, ok := p.AuthInfo.(credentials.TLSInfo); ok {
+				for _, item := range mtls.State.PeerCertificates {
+					log.WithFields(log.Fields{"subject": item.Subject}).Info("grpc cert")
+				}
 			}
 		}
-	}
+	*/
 	return handler(ctx, req)
 }
 

--- a/vendor/github.com/neuvector/neuvector/share/container/docker.go
+++ b/vendor/github.com/neuvector/neuvector/share/container/docker.go
@@ -119,12 +119,10 @@ func (d *dockerDriver) ListContainerIDs() (utils.Set, utils.Set) {
 }
 
 func (d *dockerDriver) ListContainers(runningOnly bool) ([]*ContainerMeta, error) {
-	var containers []dockerclient.Container
-
-	if runningOnly {
-		containers, _ = d.client.ListContainers(false, false, "")
-	} else {
-		containers, _ = d.client.ListContainers(true, false, "")
+	containers, err := d.client.ListContainers( !runningOnly, false, "")
+	if err != nil {
+		log.WithFields(log.Fields{"error": err, "runningOnly": runningOnly}).Error("Fail to list containers")
+		return nil, err
 	}
 
 	metas := make([]*ContainerMeta, len(containers))

--- a/vendor/github.com/neuvector/neuvector/share/global/global.go
+++ b/vendor/github.com/neuvector/neuvector/share/global/global.go
@@ -1,8 +1,10 @@
 package global
 
 import (
+	"errors"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/container"
@@ -16,6 +18,8 @@ type orchHub struct {
 	orchAPI.ResourceDriver
 }
 
+var ErrEmptyContainerList = errors.New("Container list is empty")
+
 type RegisterDriverFunc func(platform, flavor, network string) orchAPI.ResourceDriver
 
 var SYS *system.SystemTools
@@ -24,18 +28,25 @@ var ORCH *orchHub
 
 func SetGlobalObjects(rtSocket string, regResource RegisterDriverFunc) (string, string, string, []*container.ContainerMeta, error) {
 	var err error
+	var containers []*container.ContainerMeta
 
 	SYS = system.NewSystemTools()
 
 	RT, err = container.Connect(rtSocket, SYS)
-	if err != nil {
+ 	if err != nil {
 		return "", "", "", nil, err
 	}
 
-	// List only running containers
-	containers, err := RT.ListContainers(true)
-	if err != nil {
-		return "", "", "", nil, err
+	// List only at least one running containers: 3 tries
+	for i := 0; i < 3; i++ {
+		if containers, err = RT.ListContainers(true); err == nil && len(containers) > 0 {
+			break
+		}
+		time.Sleep(time.Millisecond * 50)
+	}
+
+	if len(containers) == 0 {
+		return "", "", "", nil, ErrEmptyContainerList
 	}
 
 	platform, flavor, network := getPlatform(containers)

--- a/vendor/github.com/neuvector/neuvector/share/osutil/file_linux.go
+++ b/vendor/github.com/neuvector/neuvector/share/osutil/file_linux.go
@@ -25,6 +25,7 @@ const (
 var packageFiles utils.Set = utils.NewSet(
 	"/var/lib/dpkg/status",
 	"/var/lib/rpm/Packages",
+	"/var/lib/rpm/Packages.db",
 	"/lib/apk/db/installed",
 )
 

--- a/vendor/github.com/neuvector/neuvector/share/scan/compliance.go
+++ b/vendor/github.com/neuvector/neuvector/share/scan/compliance.go
@@ -263,7 +263,7 @@ var docker_image_cis_items = map[string]api.RESTBenchCheck{
 	"I.4.1": api.RESTBenchCheck{
 		TestNum:     "I.4.1",
 		Type:        "image",
-		Catalog:     "image",
+		Category:    "image",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -272,7 +272,7 @@ var docker_image_cis_items = map[string]api.RESTBenchCheck{
 	"I.4.6": api.RESTBenchCheck{
 		TestNum:     "I.4.6",
 		Type:        "image",
-		Catalog:     "image",
+		Category:    "image",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -281,7 +281,7 @@ var docker_image_cis_items = map[string]api.RESTBenchCheck{
 	"I.4.8": api.RESTBenchCheck{
 		TestNum:     "I.4.8",
 		Type:        "image",
-		Catalog:     "image",
+		Category:    "image",
 		Scored:      false,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -290,7 +290,7 @@ var docker_image_cis_items = map[string]api.RESTBenchCheck{
 	"I.4.9": api.RESTBenchCheck{
 		TestNum:     "I.4.9",
 		Type:        "image",
-		Catalog:     "image",
+		Category:    "image",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -299,7 +299,7 @@ var docker_image_cis_items = map[string]api.RESTBenchCheck{
 	"I.4.10": api.RESTBenchCheck{
 		TestNum:     "I.4.10",
 		Type:        "secret",
-		Catalog:     "image",
+		Category:    "image",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -311,7 +311,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.1": api.RESTBenchCheck{
 		TestNum:     "D.1.1.1",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -321,7 +321,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.2": api.RESTBenchCheck{
 		TestNum:     "D.1.1.2",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -331,7 +331,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.3": api.RESTBenchCheck{
 		TestNum:     "D.1.1.3",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -341,7 +341,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.4": api.RESTBenchCheck{
 		TestNum:     "D.1.1.4",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -351,7 +351,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.5": api.RESTBenchCheck{
 		TestNum:     "D.1.1.5",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -361,7 +361,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.6": api.RESTBenchCheck{
 		TestNum:     "D.1.1.6",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -371,7 +371,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.7": api.RESTBenchCheck{
 		TestNum:     "D.1.1.7",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -381,7 +381,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.8": api.RESTBenchCheck{
 		TestNum:     "D.1.1.8",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -391,7 +391,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.9": api.RESTBenchCheck{
 		TestNum:     "D.1.1.9",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -401,7 +401,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.10": api.RESTBenchCheck{
 		TestNum:     "D.1.1.10",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -411,7 +411,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.11": api.RESTBenchCheck{
 		TestNum:     "D.1.1.11",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -421,7 +421,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.12": api.RESTBenchCheck{
 		TestNum:     "D.1.1.12",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -431,7 +431,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.13": api.RESTBenchCheck{
 		TestNum:     "D.1.1.13",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -441,7 +441,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.14": api.RESTBenchCheck{
 		TestNum:     "D.1.1.14",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -451,7 +451,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.15": api.RESTBenchCheck{
 		TestNum:     "D.1.1.15",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -461,7 +461,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.16": api.RESTBenchCheck{
 		TestNum:     "D.1.1.16",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -471,7 +471,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.17": api.RESTBenchCheck{
 		TestNum:     "D.1.1.17",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -481,7 +481,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.1.18": api.RESTBenchCheck{
 		TestNum:     "D.1.1.18",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -491,7 +491,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.2.1": api.RESTBenchCheck{
 		TestNum:     "D.1.2.1",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -501,7 +501,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.1.2.2": api.RESTBenchCheck{
 		TestNum:     "D.1.2.2",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -511,7 +511,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.1": api.RESTBenchCheck{
 		TestNum:     "D.2.1",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -521,7 +521,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.2": api.RESTBenchCheck{
 		TestNum:     "D.2.2",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -531,7 +531,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.3": api.RESTBenchCheck{
 		TestNum:     "D.2.3",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -541,7 +541,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.4": api.RESTBenchCheck{
 		TestNum:     "D.2.4",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -551,7 +551,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.5": api.RESTBenchCheck{
 		TestNum:     "D.2.5",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -561,7 +561,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.6": api.RESTBenchCheck{
 		TestNum:     "D.2.6",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -571,7 +571,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.7": api.RESTBenchCheck{
 		TestNum:     "D.2.7",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -581,7 +581,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.8": api.RESTBenchCheck{
 		TestNum:     "D.2.8",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -591,7 +591,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.9": api.RESTBenchCheck{
 		TestNum:     "D.2.9",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -601,7 +601,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.10": api.RESTBenchCheck{
 		TestNum:     "D.2.10",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -611,7 +611,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.11": api.RESTBenchCheck{
 		TestNum:     "D.2.11",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -621,7 +621,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.12": api.RESTBenchCheck{
 		TestNum:     "D.2.12",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -631,7 +631,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.13": api.RESTBenchCheck{
 		TestNum:     "D.2.13",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -641,7 +641,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.14": api.RESTBenchCheck{
 		TestNum:     "D.2.14",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -651,7 +651,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.15": api.RESTBenchCheck{
 		TestNum:     "D.2.15",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -661,7 +661,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.16": api.RESTBenchCheck{
 		TestNum:     "D.2.16",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -671,7 +671,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.17": api.RESTBenchCheck{
 		TestNum:     "D.2.17",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -681,7 +681,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.2.18": api.RESTBenchCheck{
 		TestNum:     "D.2.18",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -691,7 +691,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.1": api.RESTBenchCheck{
 		TestNum:     "D.3.1",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -701,7 +701,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.2": api.RESTBenchCheck{
 		TestNum:     "D.3.2",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -711,7 +711,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.3": api.RESTBenchCheck{
 		TestNum:     "D.3.3",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -721,7 +721,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.4": api.RESTBenchCheck{
 		TestNum:     "D.3.4",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -731,7 +731,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.5": api.RESTBenchCheck{
 		TestNum:     "D.3.5",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -741,7 +741,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.6": api.RESTBenchCheck{
 		TestNum:     "D.3.6",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -751,7 +751,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.7": api.RESTBenchCheck{
 		TestNum:     "D.3.7",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -761,7 +761,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.8": api.RESTBenchCheck{
 		TestNum:     "D.3.8",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -771,7 +771,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.9": api.RESTBenchCheck{
 		TestNum:     "D.3.9",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -781,7 +781,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.10": api.RESTBenchCheck{
 		TestNum:     "D.3.10",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -791,7 +791,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.11": api.RESTBenchCheck{
 		TestNum:     "D.3.11",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -801,7 +801,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.12": api.RESTBenchCheck{
 		TestNum:     "D.3.12",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -811,7 +811,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.13": api.RESTBenchCheck{
 		TestNum:     "D.3.13",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -821,7 +821,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.14": api.RESTBenchCheck{
 		TestNum:     "D.3.14",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -831,7 +831,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.15": api.RESTBenchCheck{
 		TestNum:     "D.3.15",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -841,7 +841,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.16": api.RESTBenchCheck{
 		TestNum:     "D.3.16",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -851,7 +851,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.17": api.RESTBenchCheck{
 		TestNum:     "D.3.17",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -861,7 +861,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.18": api.RESTBenchCheck{
 		TestNum:     "D.3.18",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -871,7 +871,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.19": api.RESTBenchCheck{
 		TestNum:     "D.3.19",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -881,7 +881,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.20": api.RESTBenchCheck{
 		TestNum:     "D.3.20",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -891,7 +891,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.21": api.RESTBenchCheck{
 		TestNum:     "D.3.21",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -901,7 +901,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.3.22": api.RESTBenchCheck{
 		TestNum:     "D.3.22",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -911,7 +911,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.4.1": api.RESTBenchCheck{
 		TestNum:     "D.4.1",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -921,7 +921,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.4.2": api.RESTBenchCheck{
 		TestNum:     "D.4.2",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -931,7 +931,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.4.3": api.RESTBenchCheck{
 		TestNum:     "D.4.3",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -941,7 +941,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.4.4": api.RESTBenchCheck{
 		TestNum:     "D.4.4",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -951,7 +951,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.4.5": api.RESTBenchCheck{
 		TestNum:     "D.4.5",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -961,7 +961,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.4.6": api.RESTBenchCheck{
 		TestNum:     "D.4.6",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -971,7 +971,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.4.7": api.RESTBenchCheck{
 		TestNum:     "D.4.7",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -981,7 +981,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.4.8": api.RESTBenchCheck{
 		TestNum:     "D.4.8",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -991,7 +991,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.4.9": api.RESTBenchCheck{
 		TestNum:     "D.4.9",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1001,7 +1001,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.4.10": api.RESTBenchCheck{
 		TestNum:     "D.4.10",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1011,7 +1011,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.4.11": api.RESTBenchCheck{
 		TestNum:     "D.4.11",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -1021,7 +1021,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.4.12": api.RESTBenchCheck{
 		TestNum:     "D.4.12",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -1031,7 +1031,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.6.1": api.RESTBenchCheck{
 		TestNum:     "D.6.1",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1041,7 +1041,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.6.2": api.RESTBenchCheck{
 		TestNum:     "D.6.2",
 		Type:        "host",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1051,7 +1051,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.1": api.RESTBenchCheck{
 		TestNum:     "D.5.1",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1061,7 +1061,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.2": api.RESTBenchCheck{
 		TestNum:     "D.5.2",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -1071,7 +1071,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.3": api.RESTBenchCheck{
 		TestNum:     "D.5.3",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1081,7 +1081,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.4": api.RESTBenchCheck{
 		TestNum:     "D.5.4",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1091,7 +1091,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.5": api.RESTBenchCheck{
 		TestNum:     "D.5.5",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1101,7 +1101,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.6": api.RESTBenchCheck{
 		TestNum:     "D.5.6",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1111,7 +1111,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.7": api.RESTBenchCheck{
 		TestNum:     "D.5.7",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1121,7 +1121,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.8": api.RESTBenchCheck{
 		TestNum:     "D.5.8",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1131,7 +1131,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.9": api.RESTBenchCheck{
 		TestNum:     "D.5.9",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1141,7 +1141,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.10": api.RESTBenchCheck{
 		TestNum:     "D.5.10",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1151,7 +1151,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.11": api.RESTBenchCheck{
 		TestNum:     "D.5.11",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1161,7 +1161,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.12": api.RESTBenchCheck{
 		TestNum:     "D.5.12",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1171,7 +1171,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.13": api.RESTBenchCheck{
 		TestNum:     "D.5.13",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1181,7 +1181,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.14": api.RESTBenchCheck{
 		TestNum:     "D.5.14",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1191,7 +1191,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.15": api.RESTBenchCheck{
 		TestNum:     "D.5.15",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1201,7 +1201,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.16": api.RESTBenchCheck{
 		TestNum:     "D.5.16",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1211,7 +1211,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.17": api.RESTBenchCheck{
 		TestNum:     "D.5.17",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1221,7 +1221,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.18": api.RESTBenchCheck{
 		TestNum:     "D.5.18",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1231,7 +1231,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.19": api.RESTBenchCheck{
 		TestNum:     "D.5.19",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1241,7 +1241,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.20": api.RESTBenchCheck{
 		TestNum:     "D.5.20",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1251,7 +1251,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.21": api.RESTBenchCheck{
 		TestNum:     "D.5.21",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1261,7 +1261,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.22": api.RESTBenchCheck{
 		TestNum:     "D.5.22",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -1271,7 +1271,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.23": api.RESTBenchCheck{
 		TestNum:     "D.5.23",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -1281,7 +1281,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.24": api.RESTBenchCheck{
 		TestNum:     "D.5.24",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1291,7 +1291,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.25": api.RESTBenchCheck{
 		TestNum:     "D.5.25",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1301,7 +1301,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.26": api.RESTBenchCheck{
 		TestNum:     "D.5.26",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1311,7 +1311,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.27": api.RESTBenchCheck{
 		TestNum:     "D.5.27",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1321,7 +1321,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.28": api.RESTBenchCheck{
 		TestNum:     "D.5.28",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1331,7 +1331,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.29": api.RESTBenchCheck{
 		TestNum:     "D.5.29",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      false,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -1341,7 +1341,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.30": api.RESTBenchCheck{
 		TestNum:     "D.5.30",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1351,7 +1351,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"D.5.31": api.RESTBenchCheck{
 		TestNum:     "D.5.31",
 		Type:        "container",
-		Catalog:     "docker",
+		Category:    "docker",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1361,7 +1361,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.1": api.RESTBenchCheck{
 		TestNum:     "K.1.1.1",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1371,7 +1371,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.2": api.RESTBenchCheck{
 		TestNum:     "K.1.1.2",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1381,7 +1381,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.3": api.RESTBenchCheck{
 		TestNum:     "K.1.1.3",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1391,7 +1391,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.4": api.RESTBenchCheck{
 		TestNum:     "K.1.1.4",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1401,7 +1401,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.5": api.RESTBenchCheck{
 		TestNum:     "K.1.1.5",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1411,7 +1411,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.6": api.RESTBenchCheck{
 		TestNum:     "K.1.1.6",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1421,7 +1421,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.7": api.RESTBenchCheck{
 		TestNum:     "K.1.1.7",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1431,7 +1431,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.8": api.RESTBenchCheck{
 		TestNum:     "K.1.1.8",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1441,7 +1441,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.9": api.RESTBenchCheck{
 		TestNum:     "K.1.1.9",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1451,7 +1451,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.10": api.RESTBenchCheck{
 		TestNum:     "K.1.1.10",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1461,7 +1461,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.11": api.RESTBenchCheck{
 		TestNum:     "K.1.1.11",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1471,7 +1471,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.12": api.RESTBenchCheck{
 		TestNum:     "K.1.1.12",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1481,7 +1481,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.13": api.RESTBenchCheck{
 		TestNum:     "K.1.1.13",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1491,7 +1491,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.14": api.RESTBenchCheck{
 		TestNum:     "K.1.1.14",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1501,7 +1501,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.15": api.RESTBenchCheck{
 		TestNum:     "K.1.1.15",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1511,7 +1511,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.16": api.RESTBenchCheck{
 		TestNum:     "K.1.1.16",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1521,7 +1521,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.17": api.RESTBenchCheck{
 		TestNum:     "K.1.1.17",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1531,7 +1531,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.18": api.RESTBenchCheck{
 		TestNum:     "K.1.1.18",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1541,7 +1541,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.19": api.RESTBenchCheck{
 		TestNum:     "K.1.1.19",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1551,7 +1551,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.20": api.RESTBenchCheck{
 		TestNum:     "K.1.1.20",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1561,7 +1561,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.1.21": api.RESTBenchCheck{
 		TestNum:     "K.1.1.21",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1571,7 +1571,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.1": api.RESTBenchCheck{
 		TestNum:     "K.1.2.1",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1581,7 +1581,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.2": api.RESTBenchCheck{
 		TestNum:     "K.1.2.2",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1591,7 +1591,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.3": api.RESTBenchCheck{
 		TestNum:     "K.1.2.3",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1601,7 +1601,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.4": api.RESTBenchCheck{
 		TestNum:     "K.1.2.4",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1611,7 +1611,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.5": api.RESTBenchCheck{
 		TestNum:     "K.1.2.5",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1621,7 +1621,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.6": api.RESTBenchCheck{
 		TestNum:     "K.1.2.6",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1631,7 +1631,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.7": api.RESTBenchCheck{
 		TestNum:     "K.1.2.7",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1641,7 +1641,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.8": api.RESTBenchCheck{
 		TestNum:     "K.1.2.8",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1651,7 +1651,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.9": api.RESTBenchCheck{
 		TestNum:     "K.1.2.9",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1661,7 +1661,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.10": api.RESTBenchCheck{
 		TestNum:     "K.1.2.10",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1671,7 +1671,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.11": api.RESTBenchCheck{
 		TestNum:     "K.1.2.11",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1681,7 +1681,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.12": api.RESTBenchCheck{
 		TestNum:     "K.1.2.12",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1691,7 +1691,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.13": api.RESTBenchCheck{
 		TestNum:     "K.1.2.13",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1701,7 +1701,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.14": api.RESTBenchCheck{
 		TestNum:     "K.1.2.14",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1711,7 +1711,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.15": api.RESTBenchCheck{
 		TestNum:     "K.1.2.15",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1721,7 +1721,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.16": api.RESTBenchCheck{
 		TestNum:     "K.1.2.16",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1731,7 +1731,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.17": api.RESTBenchCheck{
 		TestNum:     "K.1.2.17",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1741,7 +1741,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.18": api.RESTBenchCheck{
 		TestNum:     "K.1.2.18",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1751,7 +1751,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.19": api.RESTBenchCheck{
 		TestNum:     "K.1.2.19",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1761,7 +1761,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.20": api.RESTBenchCheck{
 		TestNum:     "K.1.2.20",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1771,7 +1771,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.21": api.RESTBenchCheck{
 		TestNum:     "K.1.2.21",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1781,7 +1781,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.22": api.RESTBenchCheck{
 		TestNum:     "K.1.2.22",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1791,7 +1791,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.23": api.RESTBenchCheck{
 		TestNum:     "K.1.2.23",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1801,7 +1801,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.24": api.RESTBenchCheck{
 		TestNum:     "K.1.2.24",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1811,7 +1811,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.25": api.RESTBenchCheck{
 		TestNum:     "K.1.2.25",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1821,7 +1821,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.26": api.RESTBenchCheck{
 		TestNum:     "K.1.2.26",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1831,7 +1831,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.27": api.RESTBenchCheck{
 		TestNum:     "K.1.2.27",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1841,7 +1841,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.28": api.RESTBenchCheck{
 		TestNum:     "K.1.2.28",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1851,7 +1851,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.29": api.RESTBenchCheck{
 		TestNum:     "K.1.2.29",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1861,7 +1861,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.30": api.RESTBenchCheck{
 		TestNum:     "K.1.2.30",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1871,7 +1871,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.31": api.RESTBenchCheck{
 		TestNum:     "K.1.2.31",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1881,7 +1881,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.32": api.RESTBenchCheck{
 		TestNum:     "K.1.2.32",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1891,7 +1891,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.33": api.RESTBenchCheck{
 		TestNum:     "K.1.2.33",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1901,7 +1901,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.34": api.RESTBenchCheck{
 		TestNum:     "K.1.2.34",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1911,7 +1911,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.2.35": api.RESTBenchCheck{
 		TestNum:     "K.1.2.35",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1921,7 +1921,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.3.1": api.RESTBenchCheck{
 		TestNum:     "K.1.3.1",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1931,7 +1931,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.3.2": api.RESTBenchCheck{
 		TestNum:     "K.1.3.2",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1941,7 +1941,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.3.3": api.RESTBenchCheck{
 		TestNum:     "K.1.3.3",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1951,7 +1951,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.3.4": api.RESTBenchCheck{
 		TestNum:     "K.1.3.4",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1961,7 +1961,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.3.5": api.RESTBenchCheck{
 		TestNum:     "K.1.3.5",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1971,7 +1971,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.3.6": api.RESTBenchCheck{
 		TestNum:     "K.1.3.6",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -1981,7 +1981,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.3.7": api.RESTBenchCheck{
 		TestNum:     "K.1.3.7",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -1991,7 +1991,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.4.1": api.RESTBenchCheck{
 		TestNum:     "K.1.4.1",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2001,7 +2001,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.1.4.2": api.RESTBenchCheck{
 		TestNum:     "K.1.4.2",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2011,7 +2011,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.2.1": api.RESTBenchCheck{
 		TestNum:     "K.2.1",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2021,7 +2021,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.2.2": api.RESTBenchCheck{
 		TestNum:     "K.2.2",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2031,7 +2031,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.2.3": api.RESTBenchCheck{
 		TestNum:     "K.2.3",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2041,7 +2041,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.2.4": api.RESTBenchCheck{
 		TestNum:     "K.2.4",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2051,7 +2051,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.2.5": api.RESTBenchCheck{
 		TestNum:     "K.2.5",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2061,7 +2061,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.2.6": api.RESTBenchCheck{
 		TestNum:     "K.2.6",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2071,7 +2071,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.2.7": api.RESTBenchCheck{
 		TestNum:     "K.2.7",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -2081,7 +2081,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.3.1.1": api.RESTBenchCheck{
 		TestNum:     "K.3.1.1",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -2091,7 +2091,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.3.2.1": api.RESTBenchCheck{
 		TestNum:     "K.3.2.1",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2101,7 +2101,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.3.2.2": api.RESTBenchCheck{
 		TestNum:     "K.3.2.2",
 		Type:        "master",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 2",
 		Automated:   false,
@@ -2111,7 +2111,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.1.1": api.RESTBenchCheck{
 		TestNum:     "K.4.1.1",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -2121,7 +2121,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.1.2": api.RESTBenchCheck{
 		TestNum:     "K.4.1.2",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -2131,7 +2131,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.1.3": api.RESTBenchCheck{
 		TestNum:     "K.4.1.3",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2141,7 +2141,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.1.4": api.RESTBenchCheck{
 		TestNum:     "K.4.1.4",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2151,7 +2151,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.1.5": api.RESTBenchCheck{
 		TestNum:     "K.4.1.5",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2161,7 +2161,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.1.6": api.RESTBenchCheck{
 		TestNum:     "K.4.1.6",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2171,7 +2171,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.1.7": api.RESTBenchCheck{
 		TestNum:     "K.4.1.7",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -2181,7 +2181,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.1.8": api.RESTBenchCheck{
 		TestNum:     "K.4.1.8",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -2191,7 +2191,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.1.9": api.RESTBenchCheck{
 		TestNum:     "K.4.1.9",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -2201,7 +2201,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.1.10": api.RESTBenchCheck{
 		TestNum:     "K.4.1.10",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -2211,7 +2211,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.2.1": api.RESTBenchCheck{
 		TestNum:     "K.4.2.1",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -2221,7 +2221,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.2.2": api.RESTBenchCheck{
 		TestNum:     "K.4.2.2",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -2231,7 +2231,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.2.3": api.RESTBenchCheck{
 		TestNum:     "K.4.2.3",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -2241,7 +2241,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.2.4": api.RESTBenchCheck{
 		TestNum:     "K.4.2.4",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -2251,7 +2251,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.2.5": api.RESTBenchCheck{
 		TestNum:     "K.4.2.5",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -2261,7 +2261,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.2.6": api.RESTBenchCheck{
 		TestNum:     "K.4.2.6",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2271,7 +2271,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.2.7": api.RESTBenchCheck{
 		TestNum:     "K.4.2.7",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2281,7 +2281,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.2.8": api.RESTBenchCheck{
 		TestNum:     "K.4.2.8",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2291,7 +2291,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.2.9": api.RESTBenchCheck{
 		TestNum:     "K.4.2.9",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 2",
 		Automated:   true,
@@ -2301,7 +2301,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.2.10": api.RESTBenchCheck{
 		TestNum:     "K.4.2.10",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   true,
@@ -2311,7 +2311,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.2.11": api.RESTBenchCheck{
 		TestNum:     "K.4.2.11",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2321,7 +2321,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.2.12": api.RESTBenchCheck{
 		TestNum:     "K.4.2.12",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      true,
 		Profile:     "Level 1",
 		Automated:   false,
@@ -2331,7 +2331,7 @@ var cis_items = map[string]api.RESTBenchCheck{
 	"K.4.2.13": api.RESTBenchCheck{
 		TestNum:     "K.4.2.13",
 		Type:        "worker",
-		Catalog:     "kubernetes",
+		Category:    "kubernetes",
 		Scored:      false,
 		Profile:     "Level 1",
 		Automated:   false,

--- a/vendor/github.com/neuvector/neuvector/share/system/cgroup_linux.go
+++ b/vendor/github.com/neuvector/neuvector/share/system/cgroup_linux.go
@@ -239,9 +239,14 @@ func getContainerIDByCgroupReaderV2(file io.ReadSeeker, choice int) (string, boo
 			if len(elements) > 2 {
 				// log.WithFields(log.Fields{"path": elements[2]}).Debug()
 				tokens := strings.Split(elements[2], "/")
-				for _, token := range tokens {
-					token = strings.TrimPrefix(token, "docker-") // TODO: other runtimes
-					token = strings.TrimPrefix(token, "crio-")
+				for i := len(tokens) - 1; i > 0; i-- {	// the last item is most possible target
+					token := tokens[i]
+					//token = strings.TrimPrefix(token, "docker-") // TODO: other runtimes
+					//token = strings.TrimPrefix(token, "crio-")
+					//token = strings.TrimPrefix(token, "cri-containerd-")
+					if index := strings.LastIndex(token, "-");  index != -1 {
+						token = token[index+1:]
+					}
 					token = strings.TrimSuffix(token, ".scope")
 					if isContainerID(token) {
 						return token, false, true
@@ -254,9 +259,11 @@ func getContainerIDByCgroupReaderV2(file io.ReadSeeker, choice int) (string, boo
 				if len(fstab) > 3 {
 					// log.WithFields(log.Fields{"fstab": fstab[3]}).Debug()
 					tokens := strings.Split(fstab[3], "/")
-					for _, token := range tokens {
-						token = strings.TrimPrefix(token, "docker-") // TODO: other runtimes
-						token = strings.TrimPrefix(token, "crio-")
+					for i := len(tokens) - 1; i > 0; i-- {
+						token := tokens[i]
+						if index := strings.LastIndex(token, "-");  index != -1 {
+							token = token[index+1:]
+						}
 						token = strings.TrimSuffix(token, ".scope")
 						if isContainerID(token) {
 							return token, false, true

--- a/vendor/github.com/neuvector/neuvector/share/system/system_linux.go
+++ b/vendor/github.com/neuvector/neuvector/share/system/system_linux.go
@@ -569,10 +569,7 @@ func (s *SystemTools) GetProcessName(pid int) (string, int, error) {
 			//if it is exe, it's a symlink, not a real one.
 			if name == "exe" || len(name) == maxStatCmdLen {
 				if cmds, err := s.ReadCmdLine(pid); err == nil && len(cmds) > 0 && cmds[0] != "" {
-					name = cmds[0]
-					if i := strings.LastIndex(name, "/"); i > 0 {
-						name = name[i+1:]
-					}
+					name = filepath.Base(cmds[0])
 				}
 			}
 		} else if strings.HasPrefix(line, "PPid:\t") {
@@ -695,14 +692,7 @@ func (s *SystemTools) IsOpenshift() (bool, error) {
 
 			// openshift 3.x
 			if cmds, err := s.ReadCmdLine(pid); err == nil && len(cmds) > 3 {
-				var procName string
-				i := strings.LastIndex(cmds[0], "/")
-				if i != -1 {
-					procName = cmds[0][i+1:]
-				} else {
-					procName = cmds[0]
-				}
-				if procName == "openshift" && cmds[1] == "start" {
+				if filepath.Base(cmds[0]) == "openshift" && cmds[1] == "start" {
 					return true, nil
 				}
 			}

--- a/vendor/github.com/neuvector/neuvector/share/utils/utils.go
+++ b/vendor/github.com/neuvector/neuvector/share/utils/utils.go
@@ -733,10 +733,15 @@ func GetCaller(skip int, excludes []string) string {
 
 	pc := make([]uintptr, 20)
 	n := runtime.Callers(skip, pc)
+	frames := runtime.CallersFrames(pc)
 OUTER:
 	for i := 0; i < n; i++ {
-		fpath := runtime.FuncForPC(pc[i]).Name()
-		// fmt.Printf("********  %s\n", fpath)
+		frame, more := frames.Next()
+		// fmt.Printf("********  %s\n", frame.Function)
+		if !more {
+			break
+		}
+		fpath := frame.Function
 		for _, exclude := range excludes {
 			if strings.Contains(fpath, exclude) {
 				continue OUTER

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -174,7 +174,7 @@ github.com/mitchellh/mapstructure
 github.com/neuvector/k8s/apis/meta/v1
 github.com/neuvector/k8s/runtime
 github.com/neuvector/k8s/runtime/schema
-# github.com/neuvector/neuvector v0.0.0-20220504163316-fb7541f75c2c
+# github.com/neuvector/neuvector v0.0.0-20220616012106-847c3fced01c
 ## explicit
 github.com/neuvector/neuvector/controller/api
 github.com/neuvector/neuvector/share


### PR DESCRIPTION
(1) Synchronized vender: github.com/neuvector/neuvector @ 847c3fced01c4aec1290e252544d0ca9d707b240 (branch 5.0.0)

(2) Implement wipe-out attributes during reconstructing images. 
We usually reconstruct an image from the "docker save" tars with "addition" and "overlay" methods. However, it did include a "deduction" method as well. Thus, we might have false-positive cases for the "whole-image" scan.

Target:
(a) deleted folders will not be included in the whole REPO/Registry scans
(b) However, they will be included when we make the individual "layer" scans.