### PR TITLE
NVSHAS-6806 oracle namespace improperly translated.

### DIFF
--- a/cvetools/cvesearch.go
+++ b/cvetools/cvesearch.go
@@ -694,7 +694,8 @@ func selectDB(nsName string) (string, int) {
 			}
 			db = common.DBAmazon
 		case "ol":
-			nsName = removeSubVersion(nsName)
+			majorVersion := majorVersion(r[2])
+			nsName = "oracle:" + majorVersion
 			db = common.DBOracle
 		case "mariner":
 			nsName = r[1] + ":" + r[2]
@@ -1252,6 +1253,12 @@ func removeSubVersion(name string) string {
 		}
 	}
 	return name
+}
+
+//majorVersion returns only the most significant version, ex: 7.8.112 -> 7
+func majorVersion(name string) string {
+	substrings := strings.Split(name, ".")
+	return substrings[0]
 }
 
 func feature2Module(namespace string, features []detectors.FeatureVersion, apps []detectors.AppFeatureVersion) []*share.ScanModule {

--- a/cvetools/cvetools_test.go
+++ b/cvetools/cvetools_test.go
@@ -55,6 +55,14 @@ func TestSelectDB(t *testing.T) {
 		"rhel:8.3":           result{"centos:8", common.DBCentos},
 		"mariner:1.0":        result{"mariner:1.0", common.DBMariner},
 		"opensuse-leap:15.2": result{"sles:l15.2", common.DBSuse},
+		"ol:7.8.2":           result{"oracle:7", common.DBOracle},
+		"ubuntu:7.1":         result{"ubuntu:7.1", common.DBUbuntu},
+		"debian:3.1":         result{"debian:3.1", common.DBDebian},
+		"server:5.4":         result{"centos:5", common.DBCentos},
+		"centos:5.4":         result{"centos:5", common.DBCentos},
+		"amzn:1.8":           result{"amzn:1", common.DBAmazon},
+		"sles:2.7":           result{"sles:2.7", common.DBSuse},
+		"opensuse-leap:2.7":  result{"sles:l2.7", common.DBSuse},
 	}
 
 	for ns, r := range tests {


### PR DESCRIPTION
The oracle namespace was being translated as ol:x.y when the format for our mapping is oracle:x. This caused an issue where the oracle was not properly checked for vulnerabilities.