### PR TITLE
NVSHAS-6653, fix for package names during jar parsing.

### DIFF
--- a/vendor/github.com/neuvector/neuvector/share/scan/apps.go
+++ b/vendor/github.com/neuvector/neuvector/share/scan/apps.go
@@ -56,6 +56,8 @@ const (
 	dotnetDepsMaxSize = 10 * 1024 * 1024
 )
 
+var javaInvalidVendorIds = map[string]bool{"%providerName": true}
+
 var verRegexp = regexp.MustCompile(`<([a-zA-Z0-9\.]+)>([0-9\.]+)</([a-zA-Z0-9\.]+)>`)
 var pyRegexp = regexp.MustCompile(`/([a-zA-Z0-9_\.]+)-([a-zA-Z0-9\.]+)[\-a-zA-Z0-9\.]*\.(egg-info\/PKG-INFO|dist-info\/WHEEL)$`)
 var rubyRegexp = regexp.MustCompile(`/([a-zA-Z0-9_\-]+)-([0-9\.]+)\.gemspec$`)
@@ -392,12 +394,13 @@ func (s *ScanApps) parseJarPackage(r zip.Reader, tfile, filename, fullpath strin
 					title = strings.TrimSpace(strings.TrimPrefix(line, javaMnfstBundleTitle))
 				}
 
+				title = strings.Split(title, ";")[0]
 				if len(vendorId) > 0 && len(title) > 0 && len(version) > 0 {
 					break
 				}
 			}
 
-			if len(vendorId) == 0 {
+			if len(vendorId) == 0 || javaInvalidVendorIds[vendorId] {
 				vendorId = "jar"
 			}
 
@@ -413,6 +416,7 @@ func (s *ScanApps) parseJarPackage(r zip.Reader, tfile, filename, fullpath strin
 				ModuleName: fmt.Sprintf("%s:%s", vendorId, title),
 				Version:    version,
 			}
+
 			pkgs[path] = []AppPackage{pkg}
 		}
 	}


### PR DESCRIPTION
Fixes an issue where vendorId and title can be malformatted during jar parsing.