### PR TITLE
NVSHAS-8066: the last root of trust's result(no-verifier-matched or v…

### DIFF
--- a/cvetools/sigstore.go
+++ b/cvetools/sigstore.go
@@ -77,7 +77,7 @@ func createConfFile(imgDigest string) (path string, file *os.File, err error) {
 func parseVerifiersFromBinaryOutput(output string) []string {
 	outputLines := strings.Split(output, "\n")
 	lastLine := outputLines[len(outputLines)-2]
-	satisfiedVerifiers := strings.Split(lastLine[1:len(lastLine)-1], ", ")
+	satisfiedVerifiers := strings.Split(strings.TrimSpace(lastLine), ", ")
 	return satisfiedVerifiers
 }
 


### PR DESCRIPTION
…erifier-matched) is used as the final result no matter what's the result from other root of trusts