### PR TITLE
NVSHAS-7882: add proxy url to sigstore interface execution

### DIFF
--- a/cvetools/cvesearch.go
+++ b/cvetools/cvesearch.go
@@ -1397,7 +1397,7 @@ func getSatisfiedSignatureVerifiersForImage(rc *scan.RegClient, req *share.ScanI
 
 	log.WithFields(log.Fields{"imageDigest": info.Digest}).Info("Done fetching signature data for image.")
 
-	satisfiedVerifiers, err := verifyImageSignatures(info.Digest, req.RootsOfTrust, signatureData)
+	satisfiedVerifiers, err := verifyImageSignatures(info.Digest, req.RootsOfTrust, signatureData, req.Proxy)
 	if err != nil {
 		log.WithFields(log.Fields{"imageDigest": info.Digest, "err": err}).Error()
 		sigInfo.VerificationError = share.ScanErrorCode_ScanErrRegistryAPI


### PR DESCRIPTION
Uses the new `--proxy-url` command line argument when executing the sigstore-interface binary with a proxy url in the request.