### PR TITLE
NVSHAS-7664: Help reduce ISP data charges when performing registry scanning

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -151,6 +151,11 @@ var DebianReleasesMapping = map[string]string{
 // --
 
 const ImageWorkingPath = "/tmp/images"
+const ImageLayersCachePath = "/tmp/images/caches"
+const ImageLayerLockFile = ImageLayersCachePath + "/lock"
+const ImageLayerCacherFile = ImageLayersCachePath + "/cacher.json"
+const MaxRawDataCacherSizeMB = 0  // disabled
+const MaxRecordCacherSizeMB = 1000
 
 func GetImagePath(uid string) string {
 	return filepath.Join(ImageWorkingPath, uid)

--- a/cvetools/scan_cache.go
+++ b/cvetools/scan_cache.go
@@ -1,0 +1,357 @@
+package cvetools
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"syscall"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/neuvector/neuvector/share"
+	"github.com/neuvector/neuvector/share/utils"
+)
+
+type SecretPermLogs struct {
+	SecretLogs  []*share.ScanSecretLog		`json:"secrets,omitempty"`
+	SetidPerm 	[]*share.ScanSetIdPermLog	`json:"set_ids,omitempty"`
+}
+
+type ContainerFileMap struct {
+	FileMap		map[string]string	`json:"file_map,omitempty"`
+}
+
+type cacheData struct {
+	Path	string		`json:"path"`
+	Size	int64		`json:"size"`
+	RefCnt	uint32		`json:"ref_cnt"`
+	RefLast	time.Time	`json:"ref_last"`
+}
+
+type CacherData struct {
+	CacheLayerMap 	map[string]*cacheData	`json:"cache_data,omitempty"`
+	CacheRecordMap 	map[string]*cacheData	`json:"cache_records,omitempty"`
+	CurLayerSize   	int64					`json:"current_layer_size"`
+	CurRecordSize   int64					`json:"current_record_size"`
+}
+
+type ImageLayerCacher struct {
+	flock			int
+	cachePath 		string
+	dataFile		string
+    lockFile		string
+	maxLayerSize   	int64	// raw data
+	maxRecordSize	int64	// scanned data: modules
+}
+
+const pickVictimCnt = 8
+const subLayerFolder = "data"
+const subRecordFolder = "ref"
+
+////////
+func InitImageLayerCacher(cacheFile, lockFile, cachePath string, maxLayerSize, maxRecordSize int64) (*ImageLayerCacher, error) {
+	log.WithFields(log.Fields{"maxLayerSize": maxLayerSize, "maxRecordSize": maxRecordSize}).Info()
+	if maxLayerSize == 0 && maxRecordSize == 0 {
+		return nil, nil
+	}
+	log.WithFields(log.Fields{"cacheFile": cacheFile, "lockFile": lockFile, "cachePath": cachePath}).Debug()
+
+	os.MkdirAll(cachePath, 0755)
+	os.MkdirAll(filepath.Join(cachePath, subLayerFolder), 0755)
+	os.MkdirAll(filepath.Join(cachePath, subRecordFolder), 0755)
+
+	maxLayerSize = maxLayerSize*1024*1024
+	maxRecordSize = maxRecordSize*1024*1024
+	return &ImageLayerCacher{
+		flock:			-1,
+		lockFile:       lockFile,
+		dataFile:  		cacheFile,
+		cachePath: 		cachePath,
+		maxLayerSize: 	maxLayerSize,
+		maxRecordSize: 	maxRecordSize,
+	}, nil
+}
+
+func (lc *ImageLayerCacher) LeaveLayerCacher() {
+	log.Debug()
+	syscall.Close(lc.flock)
+}
+
+func (lc *ImageLayerCacher) IsLayerDataDisable() bool {
+	return (lc.maxLayerSize < 1)
+}
+
+func (lc *ImageLayerCacher) lock() {
+	if lc.flock == -1 { // need to keep it within the same goroutine (pid)
+		if fd, err := syscall.Open(lc.lockFile, syscall.O_CREAT|syscall.O_RDONLY, 0600); err == nil {
+			lc.flock = fd
+		} else {
+			log.WithFields(log.Fields{"error": err}).Error("Lock failed")
+			return
+		}
+	}
+
+	if err := syscall.Flock(lc.flock, syscall.LOCK_EX); err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("Wait")
+	}
+	// log.WithFields(log.Fields{"fn": utils.GetCaller(3, nil)}).Debug()
+	// time.Sleep(time.Second*10)
+}
+
+func (lc *ImageLayerCacher) unlock() {
+	// log.WithFields(log.Fields{"fn": utils.GetCaller(3, nil)}).Debug()
+	syscall.Flock(lc.flock, syscall.LOCK_UN)
+}
+
+func (lc *ImageLayerCacher) readCacheFile() *CacherData {
+	var cache CacherData
+	file, _ := ioutil.ReadFile(lc.dataFile)
+	json.Unmarshal([]byte(file), &cache)
+	if cache.CacheLayerMap == nil {
+		cache.CacheLayerMap = make(map[string]*cacheData)
+	}
+	if cache.CacheRecordMap == nil {
+		cache.CacheRecordMap = make(map[string]*cacheData)
+	}
+
+	// log.WithFields(log.Fields{"cache": cache}).Debug()
+	return &cache // return empty data even if does not exist
+}
+
+func (lc *ImageLayerCacher) writeCacheFile(cache *CacherData) {
+	data, _ := json.Marshal(cache)
+	// log.WithFields(log.Fields{"data": string(data)}).Debug()
+	ioutil.WriteFile(lc.dataFile, data, 0644)
+}
+
+///////////////// Record caches ////////////////
+func (lc *ImageLayerCacher) RecordName(id string, record interface{}) string {
+	switch record.(type) {
+		case *LayerFiles:  // scan package
+			return id + "_" + "layer_file"
+		case *SecretPermLogs:
+			return id + "_" + "secrets"
+		case *ContainerFileMap:
+			return id + "_" + "fmap"
+	}
+	return ""
+}
+
+func (lc *ImageLayerCacher) ReadRecordCache(id string, record interface{}) (string, error) {
+	name := lc.RecordName(id, record)
+	if name == "" {
+		return "", errors.New("Invalid type")
+	}
+
+	// log.WithFields(log.Fields{"name": name}).Debug()
+
+	lc.lock()
+	defer lc.unlock()
+
+	cacher := lc.readCacheFile()
+	cc, ok := cacher.CacheRecordMap[name]
+	if !ok {
+		return "", errors.New("Not found: " + name)
+	}
+
+	defer lc.writeCacheFile(cacher) // update reference count
+
+	// double check
+	if _, err := os.Stat(cc.Path); err != nil {
+		cacher.CurLayerSize -= cc.Size
+		delete(cacher.CacheLayerMap, id)
+		return "", err
+	}
+
+	value, _ := ioutil.ReadFile(cc.Path)
+	uzb := utils.GunzipBytes(value)
+	json.Unmarshal([]byte(uzb), record)
+	cc.RefCnt++
+	cc.RefLast = time.Now()
+	// log.WithFields(log.Fields{"cc": cc}).Debug()
+	return cc.Path, nil
+}
+
+func (lc *ImageLayerCacher) WriteRecordCache(id string, record interface{}, keeper utils.Set) error {
+	name := lc.RecordName(id, record)
+	if name == "" {
+		return errors.New("Invalid type")
+	}
+
+	// log.WithFields(log.Fields{"name": name}).Debug()
+
+	lc.lock()
+	defer lc.unlock()
+
+	cacher := lc.readCacheFile()
+	if _, ok := cacher.CacheRecordMap[name]; !ok {
+		dest := filepath.Join(lc.cachePath, subRecordFolder, name)
+		data, _ := json.Marshal(record)
+		zb := utils.GzipBytes(data)
+		if err := ioutil.WriteFile(dest, zb, 0644); err != nil {
+			log.WithFields(log.Fields{"error": err, "dest": dest}).Error()
+		}
+		size := int64(len(zb))
+		cacher.CurRecordSize += size
+		cacher.CacheRecordMap[name] = &cacheData { Path: dest, Size: size, RefLast: time.Now(),}
+		// log.WithFields(log.Fields{"dest": dest, "size": size}).Debug()
+
+		// prune the cacher size
+		lc.pruneRecordCache(name, cacher, keeper)
+	}
+	lc.writeCacheFile(cacher)
+	return nil
+}
+
+func (lc *ImageLayerCacher) pruneRecordCache(name string, cacher *CacherData, keepers utils.Set) {
+	// log.WithFields(log.Fields{"curRecSize": cacher.CurRecordSize, "max": lc.maxRecordSize, "keepers": keepers}).Debug()
+	if cacher.CurRecordSize < lc.maxRecordSize {
+		return
+	}
+
+	// exclude current cached layers, pick 8-16 victims
+	var keys []string
+	for key, _ := range cacher.CacheRecordMap {
+		if keepers.Contains(key) {
+			continue
+		}
+		keys = append(keys, key)
+	}
+
+	if len(keys) > pickVictimCnt {
+		sort.SliceStable(keys, func(i, j int) bool {
+			return cacher.CacheRecordMap[keys[i]].RefLast.Before(cacher.CacheRecordMap[keys[j]].RefLast)
+			// return cacher.CacheRecordMap[keys[i]].RefCnt < cacher.CacheRecordMap[keys[j]].RefCnt
+		})
+	}
+
+	var removedSize int64
+	for i, key := range keys {
+		if i >= pickVictimCnt {
+			break
+		}
+
+		if cc, ok := cacher.CacheRecordMap[key]; ok {
+			// log.WithFields(log.Fields{"path": cc.Path, "size": cc.Size, "last": cc.RefLast, "cnt": cc.RefCnt}).Debug("remove")
+			removedSize += cc.Size
+			os.RemoveAll(cc.Path)
+			delete(cacher.CacheRecordMap, key)
+		}
+    }
+	cacher.CurRecordSize -= removedSize
+	log.WithFields(log.Fields{"cacher": cacher, "removed": removedSize}).Debug("done")
+}
+
+///////////////// Layer data caches ////////////////
+func (lc *ImageLayerCacher) ReadLayerDataCache(layerID string) (io.ReadCloser, int64, error) {
+	lc.lock()
+	defer lc.unlock()
+
+	cacher := lc.readCacheFile()
+	cc, ok := cacher.CacheLayerMap[layerID]
+	if !ok {
+		return nil, 0, errors.New("not found")
+	}
+
+	defer lc.writeCacheFile(cacher) // update reference count
+
+	// double check
+	if _, err := os.Stat(cc.Path); err != nil {
+		cacher.CurLayerSize -= cc.Size
+		delete(cacher.CacheLayerMap, layerID)
+		return nil, 0, errors.New("not exist")
+	}
+	rd, _ := os.Open(cc.Path)
+	cc.RefCnt++
+	cc.RefLast = time.Now()
+	log.WithFields(log.Fields{"cc": cc}).Debug()
+	return rd, cc.Size, nil
+}
+
+func (lc *ImageLayerCacher) WriteLayerDataCache(layerID string, rd io.ReadCloser, size int64, keeper utils.Set) (io.ReadCloser, error) {
+	// log.WithFields(log.Fields{"layerID": layerID}).Debug()
+	lc.lock()
+	defer lc.unlock()
+
+	cacher := lc.readCacheFile()
+	if _, ok := cacher.CacheLayerMap[layerID]; !ok {
+		dest := filepath.Join(lc.cachePath, subLayerFolder, layerID)
+		outFile, err := os.Create(dest)
+		if err != nil {
+			log.WithFields(log.Fields{"dest": dest, "error": err}).Error()
+			return rd, err
+		}
+		defer outFile.Close()
+		if _, err = io.Copy(outFile, rd); err != nil {
+			log.WithFields(log.Fields{"dest": dest, "error": err, "size": size}).Error()
+			return rd, err
+		}
+		rd, _ = os.Open(dest)   // rebuild the io reader
+		cacher.CurLayerSize += size
+		cacher.CacheLayerMap[layerID] = &cacheData { Path: dest, Size: size, RefLast: time.Now(),}
+		// log.WithFields(log.Fields{"dest": dest, "size": size}).Debug("data: wr")
+
+		// prune the cacher size
+		lc.pruneLayerDataCache(cacher, keeper)
+	}
+	lc.writeCacheFile(cacher)
+	return rd, nil
+}
+
+func (lc *ImageLayerCacher) pruneLayerDataCache(cacher *CacherData, keeper utils.Set) {
+	// log.WithFields(log.Fields{"curSize": cacher.CurLayerSize}).Debug()
+	if cacher.CurLayerSize < lc.maxLayerSize {
+		return
+	}
+
+	// exclude current cached layers, pick 8-16 victims
+	var keys []string
+	for layerID, _ := range cacher.CacheLayerMap {
+		if keeper.Contains(layerID) {
+			continue
+		}
+		keys = append(keys, layerID)
+	}
+
+	if len(keys) > pickVictimCnt {
+		sort.SliceStable(keys, func(i, j int) bool {
+			return cacher.CacheRecordMap[keys[i]].RefLast.Before(cacher.CacheRecordMap[keys[j]].RefLast)
+			// return cacher.CacheLayerMap[keys[i]].RefCnt < cacher.CacheLayerMap[keys[j]].RefCnt
+		})
+	}
+
+	var removedSize int64
+	for i, layerID := range keys {
+		if i >= pickVictimCnt {
+			break
+		}
+
+		if cc, ok := cacher.CacheLayerMap[layerID]; ok {
+			// log.WithFields(log.Fields{"path": cc.Path, "size": cc.Size, "last": cc.RefLast, "cnt": cc.RefCnt}).Debug("remove")
+			removedSize += cc.Size
+			os.RemoveAll(cc.Path)
+			delete(cacher.CacheLayerMap, layerID)
+		}
+    }
+	cacher.CurLayerSize -= removedSize
+	log.WithFields(log.Fields{"cacher": cacher, "removed": removedSize}).Debug("done")
+}
+
+
+func (lc *ImageLayerCacher) IsExistInCache(files []string) (string, bool) {
+	lc.lock()
+	defer lc.unlock()
+
+	cacher := lc.readCacheFile()
+	for _, name := range files {
+		if _, ok := cacher.CacheRecordMap[name]; !ok {
+			return name, false	// return first missing item
+		}
+	}
+	return "", true
+}

--- a/cvetools/types.go
+++ b/cvetools/types.go
@@ -20,9 +20,10 @@ type updateData struct {
 
 type ScanTools struct {
 	common.CveDB
-	RtSock    string
-	SupportOs utils.Set
-	sys       *system.SystemTools
+	RtSock      string
+	SupportOs   utils.Set
+	sys         *system.SystemTools
+	LayerCacher *ImageLayerCacher
 }
 
 type vulShortReport struct {

--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -39,6 +39,10 @@
 #define ENV_SCANNER_BASE_IMAGE  "SCANNER_BASE_IMAGE"
 #define ENV_SCANNER_CTRL_USER   "SCANNER_CTRL_API_USERNAME"
 #define ENV_SCANNER_CTRL_PASS   "SCANNER_CTRL_API_PASSWORD"
+#define ENV_SCANNER_CTRL_PASS   "SCANNER_CTRL_API_PASSWORD"
+
+#define ENV_CACHE_RAW_MAX       "MAX_CACHE_RAW_MB"
+#define ENV_CACHE_RECORD_MAX    "MAX_CACHE_RECORD_MB"
 
 enum {
     PROC_SCANNER = 0,
@@ -117,7 +121,7 @@ static pid_t fork_exec(int i)
     char *args[PROC_ARGS_MAX], *join, *adv, *url;
     char *join_port, *adv_port;
     char *license, *registry, *repository, *tag, *user, *pass, *base, *api_user, *api_pass, *enable;
-    char *on_demand;
+    char *on_demand, *cache_layer_max, *cache_record_max;
     int a;
 
     switch (i) {
@@ -222,7 +226,14 @@ static pid_t fork_exec(int i)
             args[a ++] = "--ctrl_password";
             args[a ++] = api_pass;
         }
-
+        if ((cache_layer_max = getenv(ENV_CACHE_RAW_MAX)) != NULL) {
+               args[a ++] = "-maxrac";
+               args[a ++] = cache_layer_max;
+        }
+        if ((cache_record_max = getenv(ENV_CACHE_RECORD_MAX)) != NULL) {
+               args[a ++] = "-maxrec";
+               args[a ++] = cache_record_max;
+        }
         args[a] = NULL;
         break;
     default:

--- a/scanner.go
+++ b/scanner.go
@@ -178,7 +178,8 @@ func main() {
 	show := flag.String("show", "", "Standalone Mode: Stdout print options, cmd,module")
 	getVer := flag.Bool("v", false, "show cve database version")
 	debug := flag.String("debug", "", "debug filters")
-
+	maxCacherRawDataSize := flag.Int64("maxrac", common.MaxRawDataCacherSizeMB, "maximum raw data cacher size in MB")
+	maxCacherRecordSize := flag.Int64("maxrec", common.MaxRecordCacherSizeMB, "maximum record cacher size in MB")
 	flag.Usage = usage
 	flag.Parse()
 
@@ -249,7 +250,8 @@ func main() {
 	}
 
 	if *noTask == false {
-		scanTasker = newTasker(taskerPath, *rtSock, showTaskDebug, sys)
+		log.WithFields(log.Fields{"raw": *maxCacherRawDataSize, "record": *maxCacherRecordSize}).Info("Scan cacher maximum sizes")
+		scanTasker = newTasker(taskerPath, *rtSock, showTaskDebug, sys, *maxCacherRawDataSize, *maxCacherRecordSize)
 		if scanTasker != nil {
 			log.Debug("Use scannerTask")
 			defer scanTasker.Close()

--- a/server.go
+++ b/server.go
@@ -90,8 +90,7 @@ func (rs *rpcService) ScanRunning(ctx context.Context, req *share.ScanRunningReq
 		return scanTasker.Run(ctx, *data)
 	}
 
-	sys := system.NewSystemTools()
-	cveTools := cvetools.NewScanTools("", sys)
+	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
 	return cveTools.ScanImageData(data)
 }
 
@@ -101,8 +100,7 @@ func (rs *rpcService) ScanImageData(ctx context.Context, data *share.ScanData) (
 		return scanTasker.Run(ctx, *data)
 	}
 
-	sys := system.NewSystemTools()
-	cveTools := cvetools.NewScanTools("", sys)
+	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
 	return cveTools.ScanImageData(data)
 }
 
@@ -115,8 +113,7 @@ func (rs *rpcService) ScanImage(ctx context.Context, req *share.ScanImageRequest
 		return scanTasker.Run(ctx, *req)
 	}
 
-	sys := system.NewSystemTools()
-	cveTools := cvetools.NewScanTools("", sys)
+	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
 	return cveTools.ScanImage(ctx, req, "")
 }
 
@@ -126,8 +123,7 @@ func (rs *rpcService) ScanAppPackage(ctx context.Context, req *share.ScanAppRequ
 		return scanTasker.Run(ctx, *req)
 	}
 
-	sys := system.NewSystemTools()
-	cveTools := cvetools.NewScanTools("", sys)
+	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
 	return cveTools.ScanAppPackage(req, "")
 }
 
@@ -137,8 +133,7 @@ func (rs *rpcService) ScanAwsLambda(ctx context.Context, req *share.ScanAwsLambd
 		return scanTasker.Run(ctx, *req)
 	}
 
-	sys := system.NewSystemTools()
-	cveTools := cvetools.NewScanTools("", sys)
+	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
 	return cveTools.ScanAwsLambda(req, "")
 }
 

--- a/standalone.go
+++ b/standalone.go
@@ -245,7 +245,7 @@ func scanRunning(pid int, cvedb map[string]*share.ScanVulnerability, showOptions
 	sys := system.NewSystemTools()
 	sysInfo := sys.GetSystemInfo()
 	scanUtil := scan.NewScanUtil(sys)
-	cveTools := cvetools.NewScanTools("", sys)
+	cveTools := cvetools.NewScanTools("", sys, nil)
 
 	var data share.ScanData
 	data.Buffer, data.Error = scanUtil.GetRunningPackages("1", share.ScanObjectType_HOST, pid, sysInfo.Kernel.Release)
@@ -291,8 +291,7 @@ func scanOnDemand(req *share.ScanImageRequest, cvedb map[string]*share.ScanVulne
 	if scanTasker != nil {
 		result, err = scanTasker.Run(ctx, *req)
 	} else {
-		sys := system.NewSystemTools()
-		cveTools := cvetools.NewScanTools("", sys)
+		cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
 		result, err = cveTools.ScanImage(ctx, req, "")
 	}
 	cancel()
@@ -308,8 +307,7 @@ func scanOnDemand(req *share.ScanImageRequest, cvedb map[string]*share.ScanVulne
 		if scanTasker != nil {
 			result, err = scanTasker.Run(ctx, *req)
 		} else {
-			sys := system.NewSystemTools()
-			cveTools := cvetools.NewScanTools("", sys)
+			cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
 			result, err = cveTools.ScanImage(ctx, req, "")
 		}
 		cancel()

--- a/task/scannerTask.go
+++ b/task/scannerTask.go
@@ -97,12 +97,17 @@ func main() {
 	infile := flag.String("i", "input.json", "input json name")    // uuid input filename
 	outfile := flag.String("o", "result.json", "output json name") // uuid output filename
 	rtSock := flag.String("u", "", "Container socket URL")         // used for scan local image
+	maxCacherRawDataSize := flag.Int64("maxrac", common.MaxRawDataCacherSizeMB, "maximum layer cacher size in MB")
+	maxCacherRecordSize := flag.Int64("maxrec", common.MaxRecordCacherSizeMB, "maximum layer cacher size in MB")
 	flag.Usage = usage
 	flag.Parse()
 
 	// acquire tool
-	sys := system.NewSystemTools()
-	cveTools = cvetools.NewScanTools(*rtSock, sys)
+	layerCacher, _ :=  cvetools.InitImageLayerCacher(common.ImageLayerCacherFile, common.ImageLayerLockFile, common.ImageLayersCachePath, *maxCacherRawDataSize, *maxCacherRecordSize)
+	if layerCacher != nil {
+		defer layerCacher.LeaveLayerCacher()
+	}
+	cveTools = cvetools.NewScanTools(*rtSock, system.NewSystemTools(), layerCacher)
 
 	// create an imgPath from the input file
 	var imageWorkingPath string

--- a/tasker.go
+++ b/tasker.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -31,10 +32,12 @@ type Tasker struct {
 	taskPath   string
 	rtSock     string // Container socket URL
 	sys        *system.SystemTools
+	maxCacherRawDataSize int64
+	maxCacherRecordSize  int64
 }
 
 /////
-func newTasker(taskPath, rtSock string, showDebug bool, sys *system.SystemTools) *Tasker {
+func newTasker(taskPath, rtSock string, showDebug bool, sys *system.SystemTools, maxCacherRawDataSize, maxCacherRecordSize int64) *Tasker {
 	log.WithFields(log.Fields{"showDebug": showDebug}).Debug()
 
 	return &Tasker{
@@ -43,6 +46,8 @@ func newTasker(taskPath, rtSock string, showDebug bool, sys *system.SystemTools)
 		rtSock:     rtSock,   // Container socket URL
 		bShowDebug: showDebug,
 		sys:        sys,
+		maxCacherRawDataSize: maxCacherRawDataSize,  // MB
+		maxCacherRecordSize: maxCacherRecordSize, // MB
 	}
 }
 
@@ -58,6 +63,8 @@ func (ts *Tasker) putInputFile(request interface{}) (string, []string, error) {
 		data, _ = json.Marshal(req)
 		args = append(args, "-t", "reg")
 		args = append(args, "-u", ts.rtSock)
+		args = append(args, "-maxrac", strconv.FormatInt(ts.maxCacherRawDataSize, 10))
+		args = append(args, "-maxrec", strconv.FormatInt(ts.maxCacherRecordSize, 10))
 	case share.ScanAppRequest:
 		req := request.(share.ScanAppRequest)
 		data, _ = json.Marshal(req)


### PR DESCRIPTION
Two configurable environment variables:

```
        env:
            - name: MAX_CACHE_RAW_MB                            Base OS cache
              value: "500"                                                        <== default: "0" MB (disabled)
            - name: MAX_CACHE_RECORD_MB                     Scanned record cache
              value: "512"                                                        <== default: "1000" MB
```

The two tiers of caches.
- base OS image layer data (compressed raw data files).
- scanned records, including secret scans, file maps, and layer package data (zipped JSON files).
-
About 50-70% of the scanning time could be shortened if the "repeated" layer scannings (or different databases) or same base OS images often occur.

Note: For the critical section among the multiple scannerTasks instances, the (Unix) FileLock is implemented.