### PR TITLE
NVSHAS-8907:  Scan cache (hostPath) clears up when one of the multiple scanner gets deleted

### DIFF
--- a/cvetools/cvesearch.go
+++ b/cvetools/cvesearch.go
@@ -442,13 +442,13 @@ func (cv *ScanTools) ScanImage(ctx context.Context, req *share.ScanImageRequest,
 			for _, dir := range removed[layerID] {
 				for fpath, _ := range fileMap {
 					if strings.HasPrefix(fpath, dir) {
-						log.WithFields(log.Fields{"fpath": fpath, "dir": dir}).Info("Remove")
+						// log.WithFields(log.Fields{"fpath": fpath, "dir": dir}).Debug("Remove")
 						delete(fileMap, fpath)
 					}
 				}
 			}
 
-			// log.WithFields(log.Fields{"fmap": fmap[layerID], "layerID": layerID}).Info()
+			// log.WithFields(log.Fields{"fmap": fmap[layerID], "layerID": layerID}).Debug()
 			for _, fpath := range fmap[layerID] {
 				fileMap[fpath] = layerID  // reference
 			}

--- a/scanner.go
+++ b/scanner.go
@@ -178,7 +178,7 @@ func main() {
 	show := flag.String("show", "", "Standalone Mode: Stdout print options, cmd,module")
 	getVer := flag.Bool("v", false, "show cve database version")
 	debug := flag.String("debug", "", "debug filters")
-	maxCacherRecordSize := flag.Int64("maxrec", common.MaxRecordCacherSizeMB, "maximum record cacher size in MB")
+	maxCacherRecordSize := flag.Int64("maxrec", 0, "maximum record cacher size in MB") // common.MaxRecordCacherSizeMB
 	flag.Usage = usage
 	flag.Parse()
 
@@ -228,7 +228,9 @@ func main() {
 	}
 
 	// recovered, clean up all possible previous image folders
-	os.RemoveAll(common.ImageWorkingPath)
+	if *maxCacherRecordSize <= 0 {
+		os.RemoveAll(common.ImageWorkingPath)
+	}
 	os.MkdirAll(common.ImageWorkingPath, 0755)
 
 	var err error

--- a/task/scannerTask.go
+++ b/task/scannerTask.go
@@ -97,7 +97,7 @@ func main() {
 	infile := flag.String("i", "input.json", "input json name")    // uuid input filename
 	outfile := flag.String("o", "result.json", "output json name") // uuid output filename
 	rtSock := flag.String("u", "", "Container socket URL")         // used for scan local image
-	maxCacherRecordSize := flag.Int64("maxrec", common.MaxRecordCacherSizeMB, "maximum layer cacher size in MB")
+	maxCacherRecordSize := flag.Int64("maxrec", 0, "maximum layer cacher size in MB") // common.MaxRecordCacherSizeMB
 	flag.Usage = usage
 	flag.Parse()
 


### PR DESCRIPTION
(1) Avoid the top layer of the image working folder, "/tmp/image", which is removed when the new scanner is up.

(2) Make the scanner cache is default disabled. 