### PR TITLE
Scanner cache: correct the layer orders for registry and repository scans

### DIFF
--- a/cvetools/scan_cache.go
+++ b/cvetools/scan_cache.go
@@ -144,7 +144,9 @@ func (lc *ImageLayerCacher) lock() {
 	}
 
 	if err := syscall.Flock(lc.flock, syscall.LOCK_EX); err != nil {
-		log.WithFields(log.Fields{"error": err, "flock": lc.flock}).Error("Wait")
+		if err.Error() != "bad file descriptor" {	// PVC cases
+			log.WithFields(log.Fields{"error": err, "flock": lc.flock}).Error("Wait")
+		}
 	}
 	// log.WithFields(log.Fields{"fn": utils.GetCaller(3, nil)}).Debug()
 	// time.Sleep(time.Second*10)

--- a/cvetools/tools.go
+++ b/cvetools/tools.go
@@ -95,8 +95,10 @@ func collectImageFileMap(rootPath string, fmap map[string]string) (int, []string
 
 	// (2) add the new added files
 	for path, ref := range curfmap {
-		fmap[path] = ref
-		// log.WithFields(log.Fields{"path": path}).Info("Add")
+		if path != "" {
+			fmap[path] = ref
+			// log.WithFields(log.Fields{"path": path, "ref": ref}).Info("Add")
+		}
 	}
 	return len(curfmap), opqDirs, err
 }


### PR DESCRIPTION
(1) correct the layer sequences from the image scans.
(2) REPO: replace the correct layer mapping from the image history. The (history size == 0) might have the tar layer data.
(3) Ignore the cacher's lock error messages on a PVC setup.