### PR TITLE
NVSHAS-8949: goroutine crash at cvetools.getImageLayers()

### DIFF
--- a/cvetools/image.go
+++ b/cvetools/image.go
@@ -362,7 +362,7 @@ func getImageLayers(tmpDir string, imageTar string) ([]string, map[string]string
 		return nil, nil, err
 	}
 
-	layerCount := len(fileMap)
+	layerCount := len(image[0].Layers)
 	layers := make([]string, layerCount)
 	blobs := make(map[string]string)
 	for i, ftar := range image[0].Layers {


### PR DESCRIPTION
The REPO OCI format is allowed to reuse the same layerID to layers on docker v25 platform.