### PR TITLE
NVSHAS-8995: add R-lang module parser

### DIFF
--- a/cvetools/image.go
+++ b/cvetools/image.go
@@ -446,6 +446,9 @@ func getImageLayerIterate(
 			if strings.HasPrefix(path, dockerfile) {
 				return true
 			}
+			if scan.IsRlangPackage(path) {
+				return true
+			}
 			return false
 		})
 


### PR DESCRIPTION
Add R-language module parser from their manifest files.

Sample:

```
	{
		"Name": "base",  
		"Version": "4.0.5",
		"Source": "r"
	},
```