### PR TITLE
NVSHAS-9015: goroutine crash at cvetools.(*ScanTools).DetectAppVul()

### DIFF
--- a/task/scannerTask.go
+++ b/task/scannerTask.go
@@ -107,6 +107,7 @@ func main() {
 		defer layerCacher.LeaveLayerCacher()
 	}
 	cveTools = cvetools.NewScanTools(*rtSock, system.NewSystemTools(), layerCacher)
+	common.InitDebugFilters("")
 
 	// create an imgPath from the input file
 	var imageWorkingPath string


### PR DESCRIPTION
Add a new initialization at scannerTask instance.