### PR TITLE
NVSHAS-9026: dup and missing .NET module name

### DIFF
--- a/cvetools/image.go
+++ b/cvetools/image.go
@@ -244,8 +244,8 @@ func (s *ScanTools) LoadLocalImage(ctx context.Context, repository, tag, imgPath
 	}
 
 	// Use cmds from "docker history" API, add 0-sized layer back in.
-	tarLayers := make([]string, len(histories))
-	layers = make([]string, len(histories))
+	layers = []string{}
+	tarLayers := []string{}
 	cmds := make([]string, len(histories))
 	lenML := len(meta.Layers)
 	ml := 0
@@ -260,16 +260,24 @@ func (s *ScanTools) LoadLocalImage(ctx context.Context, repository, tag, imgPath
 			}
 
 			if matched {
-				layers[i] = meta.Layers[ml]
-				tarLayers[i] = tars[ml]
+				layers = append(layers, meta.Layers[ml])
+				tarLayers = append(tarLayers, tars[ml])
 				ml++
 				continue
 			}
 		}
 
 		// empty layer
-		layers[i] = ""
-		tarLayers[i] = ""
+		layers = append(layers, "")
+		tarLayers = append(tarLayers, "")
+	}
+
+	// quay.io/nvlab/business_profile-staging:1.0.200514124656
+	// its histories is wrong and short-ed by 1 entry
+	// ==> need to pacth the reminding layers into the layers
+	for i := ml; i < lenML; i++ {
+		layers = append(layers, meta.Layers[i])
+		tarLayers = append(tarLayers, tars[i])
 	}
 
 	repoInfo := &scan.ImageInfo{

--- a/cvetools/types.go
+++ b/cvetools/types.go
@@ -24,6 +24,7 @@ type ScanTools struct {
 	SupportOs   utils.Set
 	sys         *system.SystemTools
 	LayerCacher *ImageLayerCacher
+	modulesFile string
 }
 
 type vulShortReport struct {

--- a/server.go
+++ b/server.go
@@ -91,7 +91,7 @@ func (rs *rpcService) ScanRunning(ctx context.Context, req *share.ScanRunningReq
 		return scanTasker.Run(ctx, *data)
 	}
 
-	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
+	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil, "")
 	return cveTools.ScanImageData(data)
 }
 
@@ -101,7 +101,7 @@ func (rs *rpcService) ScanImageData(ctx context.Context, data *share.ScanData) (
 		return scanTasker.Run(ctx, *data)
 	}
 
-	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
+	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil, "")
 	return cveTools.ScanImageData(data)
 }
 
@@ -114,7 +114,7 @@ func (rs *rpcService) ScanImage(ctx context.Context, req *share.ScanImageRequest
 		return scanTasker.Run(ctx, *req)
 	}
 
-	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
+	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil, "")
 	return cveTools.ScanImage(ctx, req, "")
 }
 
@@ -124,7 +124,7 @@ func (rs *rpcService) ScanAppPackage(ctx context.Context, req *share.ScanAppRequ
 		return scanTasker.Run(ctx, *req)
 	}
 
-	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
+	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil, "")
 	return cveTools.ScanAppPackage(req, "")
 }
 
@@ -134,7 +134,7 @@ func (rs *rpcService) ScanAwsLambda(ctx context.Context, req *share.ScanAwsLambd
 		return scanTasker.Run(ctx, *req)
 	}
 
-	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
+	cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil, "")
 	return cveTools.ScanAwsLambda(req, "")
 }
 

--- a/standalone.go
+++ b/standalone.go
@@ -245,7 +245,7 @@ func scanRunning(pid int, cvedb map[string]*share.ScanVulnerability, showOptions
 	sys := system.NewSystemTools()
 	sysInfo := sys.GetSystemInfo()
 	scanUtil := scan.NewScanUtil(sys)
-	cveTools := cvetools.NewScanTools("", sys, nil)
+	cveTools := cvetools.NewScanTools("", sys, nil, "")
 
 	var data share.ScanData
 	data.Buffer, data.Error = scanUtil.GetRunningPackages("1", share.ScanObjectType_HOST, pid, sysInfo.Kernel.Release, false)
@@ -291,7 +291,7 @@ func scanOnDemand(req *share.ScanImageRequest, cvedb map[string]*share.ScanVulne
 	if scanTasker != nil {
 		result, err = scanTasker.Run(ctx, *req)
 	} else {
-		cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
+		cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil, "")
 		result, err = cveTools.ScanImage(ctx, req, "")
 	}
 	cancel()
@@ -307,7 +307,7 @@ func scanOnDemand(req *share.ScanImageRequest, cvedb map[string]*share.ScanVulne
 		if scanTasker != nil {
 			result, err = scanTasker.Run(ctx, *req)
 		} else {
-			cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil)
+			cveTools := cvetools.NewScanTools("", system.NewSystemTools(), nil, "")
 			result, err = cveTools.ScanImage(ctx, req, "")
 		}
 		cancel()

--- a/task/scannerTask.go
+++ b/task/scannerTask.go
@@ -96,6 +96,7 @@ func main() {
 	scanType := flag.String("t", "", "scan type: reg, pkg, dat or awl (Required)")
 	infile := flag.String("i", "input.json", "input json name")    // uuid input filename
 	outfile := flag.String("o", "result.json", "output json name") // uuid output filename
+	modulefile := flag.String("m", "", "modules json name") // debug: modules for reg type
 	rtSock := flag.String("u", "", "Container socket URL")         // used for scan local image
 	maxCacherRecordSize := flag.Int64("maxrec", 0, "maximum layer cacher size in MB") // common.MaxRecordCacherSizeMB
 	flag.Usage = usage
@@ -106,7 +107,8 @@ func main() {
 	if layerCacher != nil {
 		defer layerCacher.LeaveLayerCacher()
 	}
-	cveTools = cvetools.NewScanTools(*rtSock, system.NewSystemTools(), layerCacher)
+
+	cveTools = cvetools.NewScanTools(*rtSock, system.NewSystemTools(), layerCacher, *modulefile)
 	common.InitDebugFilters("")
 
 	// create an imgPath from the input file


### PR DESCRIPTION
(1) Update dotNet package parser
(2) Remove the duplicated restrictions to produce module/cve entries if they are not from the same file
(3) Cacher correctness: local scans, the docker history was wrong or missing an entry. It causes the base-layer was not included.
(4) Debug purpose: add the module output from the front-end results.