### PR TITLE
[NVSHAS-9189] Scan will stuck in scheduling after controller is shutdown and restarted

### DIFF
--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -42,8 +42,6 @@
 
 #define ENV_SCANNER_CACHE_MAX   "MAX_CACHE_RECORD_MB"
 #define ENV_CAP_CRITICAL        "CAP_CRITICAL"
-#define ENV_HEALTH_CHECK_PERIOD "HEALTH_CHECK_PERIOD"
-#define ENV_RETRY               "MAX_RETRY"
 
 enum {
     PROC_SCANNER = 0,
@@ -122,7 +120,7 @@ static pid_t fork_exec(int i)
     char *args[PROC_ARGS_MAX], *join, *adv, *url;
     char *join_port, *adv_port;
     char *license, *registry, *repository, *tag, *user, *pass, *base, *api_user, *api_pass, *enable;
-    char *on_demand, *cache_record_max, *period, *retry_max;
+    char *on_demand, *cache_record_max;
     int a;
 
     switch (i) {
@@ -207,14 +205,6 @@ static pid_t fork_exec(int i)
                 args[a ++] = "--tag";
                 args[a ++] = tag;
             }
-            if ((period = getenv(ENV_HEALTH_CHECK_PERIOD)) != NULL) {
-                args[a ++] = "--period";
-                args[a ++] = period;
-            } 
-            if ((retry_max = getenv(ENV_RETRY)) != NULL) {
-                args[a ++] = "--retry_max";
-                args[a ++] = retry_max;
-            }            
         }
 
         // The following options apply to both standalone or non-standalone mode

--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -42,6 +42,8 @@
 
 #define ENV_SCANNER_CACHE_MAX   "MAX_CACHE_RECORD_MB"
 #define ENV_CAP_CRITICAL        "CAP_CRITICAL"
+#define ENV_HEALTH_CHECK_PERIOD "HEALTH_CHECK_PERIOD"
+#define ENV_RETRY               "MAX_RETRY"
 
 enum {
     PROC_SCANNER = 0,
@@ -120,7 +122,7 @@ static pid_t fork_exec(int i)
     char *args[PROC_ARGS_MAX], *join, *adv, *url;
     char *join_port, *adv_port;
     char *license, *registry, *repository, *tag, *user, *pass, *base, *api_user, *api_pass, *enable;
-    char *on_demand, *cache_record_max;
+    char *on_demand, *cache_record_max, *period, *retry_max;
     int a;
 
     switch (i) {
@@ -205,6 +207,14 @@ static pid_t fork_exec(int i)
                 args[a ++] = "--tag";
                 args[a ++] = tag;
             }
+            if ((period = getenv(ENV_HEALTH_CHECK_PERIOD)) != NULL) {
+                args[a ++] = "--period";
+                args[a ++] = period;
+            } 
+            if ((retry_max = getenv(ENV_RETRY)) != NULL) {
+                args[a ++] = "--retry_max";
+                args[a ++] = retry_max;
+            }            
         }
 
         // The following options apply to both standalone or non-standalone mode

--- a/scanner.go
+++ b/scanner.go
@@ -124,6 +124,8 @@ func connectController(path, advIP, joinIP, selfID string, advPort uint32, joinP
 		scanner.CVEDB = nil
 		dbData = make(map[string]*share.ScanVulnerability) // zero size
 
+		go periodCheckHealth(joinIP, joinPort, cb)
+
 		// start responding shutdown notice
 		cb.ignoreShutdown = false
 		<-cb.shutCh

--- a/scanner.go
+++ b/scanner.go
@@ -98,7 +98,7 @@ func dbRead(path string, maxRetry int, output string) map[string]*share.ScanVuln
 	}
 }
 
-func connectController(path, advIP, joinIP, selfID string, advPort uint32, joinPort uint16, period, retryMax int, doneCh chan bool) {
+func connectController(path, advIP, joinHost, selfID string, advPort uint32, joinPort uint16, period, retryMax int, doneCh chan bool) {
 	cb := &clientCallback{
 		shutCh:         make(chan interface{}, 1),
 		ignoreShutdown: true,
@@ -118,7 +118,7 @@ func connectController(path, advIP, joinIP, selfID string, advPort uint32, joinP
 			ID:              selfID,
 		}
 
-		for scannerRegister(joinIP, joinPort, &scanner, cb) != nil {
+		for scannerRegister(joinHost, joinPort, &scanner, cb) != nil {
 			time.Sleep(registerWaitTime)
 		}
 
@@ -131,7 +131,7 @@ func connectController(path, advIP, joinIP, selfID string, advPort uint32, joinP
 		}
 
 		healthCheckCh = make(chan struct{})
-		go periodCheckHealth(joinIP, joinPort, &scanner, cb, healthCheckCh, doneCh, period, retryMax)
+		go periodCheckHealth(joinHost, joinPort, &scanner, cb, healthCheckCh, doneCh, period, retryMax)
 
 		// start responding shutdown notice
 		cb.ignoreShutdown = false

--- a/server.go
+++ b/server.go
@@ -429,7 +429,7 @@ func getControllerHealthCheck(joinIP string, joinPort uint16, cb cluster.GRPCCal
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 	defer cancel()
 
-	_, errHealthCheck := client.HealthCheck(ctx, &share.RPCVoid{})
+	_, errHealthCheck := client.GetCaps(ctx, &share.RPCVoid{})
 
 	return errHealthCheck
 }

--- a/server.go
+++ b/server.go
@@ -434,6 +434,8 @@ func getControllerHealthCheck(joinIP string, joinPort uint16, cb cluster.GRPCCal
 	return errHealthCheck
 }
 
+// To ensure the controller's availability, periodCheckHealth use GetCaps to periodically check if the controller is alive.
+// Additionally, if the controller is deleted or not responsive, the scanner will re-register.
 func periodCheckHealth(joinIP string, joinPort uint16, cb *clientCallback) {
 	period := 30
 	ticker := time.NewTicker(time.Duration(period) * time.Minute)


### PR DESCRIPTION
### Summary

1. Add HealthCheck grpc call to check controller health periodically, if the controller is down, we restart the re-register loop
2. user is able to customize the period and retry max

### Test Performed

1. old scanner > old controller, Expected cause the scanner is unable to register the controller again, since no logic for scanner to re-register
2. old scanner > new controller, Expected cause the scanner is unable to register the controller again, since no logic for scanner to re-register
3. new scanner > old controller, Expected cause the scanner is unable to register the controller again
4. new scanner > new controller, resolve the problem







