### PR TITLE
fix: NVSHAS-9523 standalone scanner issue

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -302,9 +302,14 @@ func main() {
 			}
 		}
 	}
-	err = cluster.ReloadInternalCert()
-	if err != nil {
-		log.WithError(err).Fatal("failed to reload internal certificate")
+
+	if *license == "" {
+		// We don't need the certificate for standalone scanner.
+		// For scan result, it's via RESTful.
+		err = cluster.ReloadInternalCert()
+		if err != nil {
+			log.WithError(err).Fatal("failed to reload internal certificate")
+		}
 	}
 
 	// If license parameter is given, this is an on-demand scanner, no register to the controller,


### PR DESCRIPTION
For standalone scanner, it doesn't need to reload internal certificate.  Reloading certificate would lead to error during standalone scan when UID/GID is not 0. 

Verified both standalone and k8s scenario. 