### PR TITLE
fix: publish to rancher nv scanner v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,4 +90,5 @@ jobs:
       if: env.UPDATE_MUTABLE_TAG == 'True'
       run: |
         docker buildx imagetools create --tag ${PRIME_REGISTRY}/rancher/neuvector-scanner:6 ${PRIME_REGISTRY}/rancher/neuvector-scanner:${TAG}
+        docker buildx imagetools create --tag docker.io/rancher/neuvector-scanner:6 docker.io/rancher/neuvector-scanner:${TAG}
         docker buildx imagetools create --tag docker.io/${{ github.repository_owner }}/scanner:6 docker.io/${{ github.repository_owner }}/scanner:${TAG}


### PR DESCRIPTION
In the previous version, rancher DockerHub's v6 tag is not updated.  This PR fixes the issue.

Ideally we should move the v6 step to another job.  I will do that in another PR. 