### PR TITLE
fix: permission issues on OpenShift scanner

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -41,6 +41,7 @@ RUN zypper refresh && zypper --installroot /chroot -n in --no-recommends \
 RUN cd /chroot/usr/bin/ && rm -rf basename chcon chgrp chmod chown chroot cksum dd df dircolors dirname du install install-info join locale localedef mkdir mkfifo mknod mktemp paste pathchk readlink realpath sync smidiff smidump smilink smiquery smistrip smixlate tee tiemout tload top truncate unlink watch
 
 RUN mkdir -p /chroot/etc/neuvector/certs/internal/ && mkdir -p /chroot/share && touch /chroot/share/.nvcontainer
+RUN chmod 770 /chroot/etc/neuvector/certs/internal/
 
 #
 # Artifact


### PR DESCRIPTION
The permission is not ported to SLSA build correctly. 