### PR TITLE
[NVSHAS-9784] NV returning 404 during Jfrog image repository scanning

### DIFF
--- a/cvetools/cvesearch.go
+++ b/cvetools/cvesearch.go
@@ -303,6 +303,9 @@ func (cv *ScanTools) ScanImage(ctx context.Context, req *share.ScanImageRequest,
 
 			rc := scan.NewRegClient(baseReg, req.Token, req.Username, req.Password, req.Proxy, new(httptrace.NopTracer))
 			info, errCode = rc.GetImageInfo(ctx, baseRepo, baseTag, registry.ManifestRequest_Default)
+			if errCode == share.ScanErrorCode_ScanErrImageNotFound {
+				info, errCode = rc.GetImageInfo(ctx, baseRepo, baseTag, registry.ManifestRequest_CosignSignature)
+			}
 			if errCode != share.ScanErrorCode_ScanErrNone {
 				result.Error = errCode
 				return result, nil
@@ -317,6 +320,9 @@ func (cv *ScanTools) ScanImage(ctx context.Context, req *share.ScanImageRequest,
 
 		rc := scan.NewRegClient(req.Registry, req.Token, req.Username, req.Password, req.Proxy, new(httptrace.NopTracer))
 		info, errCode = rc.GetImageInfo(ctx, req.Repository, req.Tag, registry.ManifestRequest_Default)
+		if errCode == share.ScanErrorCode_ScanErrImageNotFound {
+			info, errCode = rc.GetImageInfo(ctx, req.Repository, req.Tag, registry.ManifestRequest_CosignSignature)
+		}
 		if errCode != share.ScanErrorCode_ScanErrNone {
 			result.Error = errCode
 			return result, nil


### PR DESCRIPTION
### Summary
- Add fallback functionality to handle reading the OCI format of a manifest.

### Root cause
The current implementation will call the following for any jfrog build when scanning

```bash
curl -u usr:pwd\
     -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
     https://nvdebug.jfrog.io/v2/{repo}/{image}/manifests/{tag}
 ```

But the header is always, this header is compatible with Docker V2 image manifests.

```bash
application/vnd.docker.distribution.manifest.v2+json 
```

However, to support OCI-compliant images (e.g., OCI build images), the header must also accept:
```bash
application/vnd.oci.image.manifest.v1+json 
```

Thus we use consigned-image as fallback function to work with it