### PR TITLE
fix: SLE-mircro 5.x using sle-micro

### DIFF
--- a/cvetools/cvesearch.go
+++ b/cvetools/cvesearch.go
@@ -923,7 +923,7 @@ func os2DB(ns *detectors.Namespace) (string, int) {
 			majorVersion := majorVersion(r[2])
 			nsName = "sles:lib" + majorVersion
 			db = common.DBSuse
-		case "sl-micro":
+		case "sl-micro", "sle-micro":
 			majorVersion := r[2]
 			nsName = "sles:micro" + majorVersion
 			db = common.DBSuse


### PR DESCRIPTION
### Summary
- SLE micro start with different prefix compare to 6.x