### PR TITLE
feat: add govulncheck workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.8.0
+          version: v2.9.0

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,32 @@
+name: govulncheck
+on:
+  push:
+    paths:
+      - go.sum
+      - go.mod
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install Golang
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          check-latest: true # Always check for the latest patch release
+      - name: Run govulncheck
+        env:
+          GOVULNCHECK_VERSION: d1f380186385b4f64e00313f31743df8e4b89a77 # v1.1.4
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@${{ env.GOVULNCHECK_VERSION }}
+          govulncheck -C . -format text ./...

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/neuvector/scanner
 
-go 1.25.0
-
-toolchain go1.25.9
+go 1.26.2
 
 replace k8s.io/cri-api => k8s.io/cri-api v0.25.16
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -4,7 +4,7 @@ ARG SIGSTORE_VERSION=426a5b0c9dff026dbc1961c81e232509a7c335cb
 #
 # Builder
 #
-FROM registry.suse.com/bci/golang:1.25 AS builder
+FROM registry.suse.com/bci/golang:1.26.2 AS builder
 ARG VERSION
 ARG VULNDB_CHECKSUM
 ARG SIGSTORE_VERSION


### PR DESCRIPTION
## Description

This PR adds govulncheck workflow.  The golang version is also upgraded to 1.26.2.  

The successully failing run: 
https://github.com/holyspectral/scanner/actions/runs/24579605495/job/71873725064

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

## Additional Information

### Tradeoff


### Potential improvement

