### PR TITLE
chore(renovate): sync renovate config with other projs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,34 @@
   "baseBranchPatterns": [
     "main"
   ],
-  "prHourlyLimit": 2
+  "prHourlyLimit": 2,
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths",
+    "gomodVendor"
+  ],
+  "ignorePaths": [
+    "vendor/**/Dockerfile",
+    "vendor/**/requirements.txt"
+  ],
+  "packageRules": [
+    {
+      "description": "Enable update on indirect imports in gomod",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": true
+    },
+    {
+      "description": "Enable updates from neuvector/neuvector",
+      "matchPackageNames": [
+        "github.com/neuvector/neuvector"
+      ], 
+      "enabled": true,
+      "ignoreUnstable": false
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION

## Description

Sync renovate config with other projs

1. Enable indirect gomod update.
2. Enable neuvector/neuvector update.
3. Disable Dockerfile and requirements in vendor/ folder.

## Test

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
