### PR TITLE
fix: use go.mod for golang version

### DIFF
--- a/.github/workflows/unitest.yaml
+++ b/.github/workflows/unitest.yaml
@@ -11,6 +11,6 @@ jobs:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
-        go-version: '1.26.3'
+        go-version-file: "go.mod"
     - run: |
         make test


### PR DESCRIPTION
## Description

We've been using `go-version-file: "go.mod"` in other places, but this file is apparently missed. 

## Test

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
