### PR TITLE
fix: disable indirect update

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,12 +24,6 @@
   ],
   "packageRules": [
     {
-      "description": "Enable update on indirect imports in gomod",
-      "matchManagers": ["gomod"],
-      "matchDepTypes": ["indirect"],
-      "enabled": true
-    },
-    {
       "description": "Enable updates from neuvector/neuvector",
       "matchPackageNames": [
         "github.com/neuvector/neuvector"


### PR DESCRIPTION

## Description

Now we can merge neuvector/neuvector update freely.  We don't have to care about indirect update.

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
