### PR TITLE
fix: release scanner fail

### DIFF
--- a/.github/actions/install-crane/action.yml
+++ b/.github/actions/install-crane/action.yml
@@ -1,0 +1,40 @@
+name: Install crane
+inputs:
+  version:
+    default: v0.21.7
+  checksum_linux_x86_64:
+    default: 1a57bc98207fa1c0d04bf760699099e26f8383499bfd55b99c1b919a928a7230
+  checksum_linux_arm64:
+    default: b6ee979d9411dfb05ce35ab9e156fe5de7def11a230764a7856ffa2eb971fa88
+
+runs:
+  using: 'composite'
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+
+        case "$(uname -m)" in
+          x86_64|amd64)
+            archive="go-containerregistry_Linux_x86_64.tar.gz"
+            checksum="${{ inputs.checksum_linux_x86_64 }}"
+            ;;
+          aarch64|arm64)
+            archive="go-containerregistry_Linux_arm64.tar.gz"
+            checksum="${{ inputs.checksum_linux_arm64 }}"
+            ;;
+          *)
+            echo "Unsupported architecture: $(uname -m)" >&2
+            exit 1
+            ;;
+        esac
+
+        install_dir="${RUNNER_TEMP}/crane-bin"
+        mkdir -p "$install_dir"
+
+        curl -fsSL "https://github.com/google/go-containerregistry/releases/download/${{ inputs.version }}/${archive}" -o crane.tar.gz
+        echo "${checksum}  crane.tar.gz" | sha256sum -c
+        tar -xzf crane.tar.gz crane
+        chmod +x crane
+        mv crane "${install_dir}/crane"
+        echo "${install_dir}" >> "$GITHUB_PATH"

--- a/.github/actions/install-crane/action.yml
+++ b/.github/actions/install-crane/action.yml
@@ -11,17 +11,21 @@ runs:
   using: 'composite'
   steps:
     - shell: bash
+      env:
+        CRANE_VERSION: ${{ inputs.version }}
+        CHECKSUM_X86_64: ${{ inputs.checksum_linux_x86_64 }}
+        CHECKSUM_ARM64: ${{ inputs.checksum_linux_arm64 }}
       run: |
         set -euo pipefail
 
         case "$(uname -m)" in
           x86_64|amd64)
             archive="go-containerregistry_Linux_x86_64.tar.gz"
-            checksum="${{ inputs.checksum_linux_x86_64 }}"
+            checksum="${CHECKSUM_X86_64}"
             ;;
           aarch64|arm64)
             archive="go-containerregistry_Linux_arm64.tar.gz"
-            checksum="${{ inputs.checksum_linux_arm64 }}"
+            checksum="${CHECKSUM_ARM64}"
             ;;
           *)
             echo "Unsupported architecture: $(uname -m)" >&2
@@ -29,12 +33,7 @@ runs:
             ;;
         esac
 
-        install_dir="${RUNNER_TEMP}/crane-bin"
-        mkdir -p "$install_dir"
-
-        curl -fsSL "https://github.com/google/go-containerregistry/releases/download/${{ inputs.version }}/${archive}" -o crane.tar.gz
+        curl -fsSL "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/${archive}" -o crane.tar.gz
         echo "${checksum}  crane.tar.gz" | sha256sum -c
         tar -xzf crane.tar.gz crane
-        chmod +x crane
-        mv crane "${install_dir}/crane"
-        echo "${install_dir}" >> "$GITHUB_PATH"
+        sudo mv crane /usr/local/bin/crane

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       uses: ./.github/actions/install-crane
     - name: Log in to GHCR
       run: |
-        echo "${{ github.token }}" | crane auth login ghcr.io -u "${{ github.actor }}" --password-stdin
+        echo "$GITHUB_TOKEN" | crane auth login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
     - name: Download vulnerability database
       env:
         GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,21 @@ jobs:
       run: |
         TARGET=${{ github.ref_name }}
         echo "TAG=${TARGET#v}" >> $GITHUB_ENV
-    - name: Download vulnerability database
+    - name: Install crane
+      uses: ./.github/actions/install-crane
+    - name: Log in to GHCR
       run: |
-        wget https://${{ secrets.VULNDB_SERVER }}/${TAG}/cvedb.regular -O data/cvedb.regular
+        echo "${{ github.token }}" | crane auth login ghcr.io -u "${{ github.actor }}" --password-stdin
+    - name: Download vulnerability database
+      env:
+        GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+      run: |
+        VULNDB_VERSION=$(grep '^ARG VULNDB_VERSION=' package/Dockerfile | cut -d= -f2)
+        bash scripts/ghcr-vulndb-artifact.sh download \
+          cvedb \
+          cvedb.regular \
+          data/cvedb.regular \
+          "${VULNDB_VERSION}"
     - name: Publish neuvector manifest
       uses: rancher/ecm-distro-tools/actions/publish-image@a7a867a6376bf4a1cee397558f3c85393769f069 # v0.69.4
       with:

--- a/scripts/ghcr-vulndb-artifact.sh
+++ b/scripts/ghcr-vulndb-artifact.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ghcr-vulndb-artifact.sh publish <artifact-name> <payload-file> <version-file> <version> [ref-file]
+  ghcr-vulndb-artifact.sh download <artifact-name> <payload-file> <destination-file> <version> [ref-file]
+
+Environment:
+  OCI_REPOSITORY_PREFIX   Defaults to ghcr.io/${GITHUB_REPOSITORY_OWNER}/vul
+EOF
+}
+
+repo_prefix() {
+  if [ -n "${OCI_REPOSITORY_PREFIX:-}" ]; then
+    printf '%s\n' "$OCI_REPOSITORY_PREFIX"
+    return 0
+  fi
+
+  if [ -n "${GITHUB_REPOSITORY_OWNER:-}" ]; then
+    printf 'ghcr.io/%s/vul\n' "$GITHUB_REPOSITORY_OWNER"
+    return 0
+  fi
+
+  echo "OCI_REPOSITORY_PREFIX or GITHUB_REPOSITORY_OWNER is required" >&2
+  exit 1
+}
+
+default_ref_file() {
+  local artifact_name=$1
+  printf '.github/vul-refs/%s.ref\n' "$artifact_name"
+}
+
+publish_artifact() {
+  local artifact_name=$1
+  local payload_file=$2
+  local version_file=$3
+  local version=$4
+  local ref_file=${5:-$(default_ref_file "$artifact_name")}
+  local prefix
+  local repository
+  local reference
+  local digest
+  local latest_digest
+  local full_reference
+  local temp_dir
+  local layer_dir
+  local layer_tar
+  local payload_basename
+
+  prefix=$(repo_prefix)
+
+  if [ ! -f "$payload_file" ]; then
+    echo "Payload file not found: $payload_file" >&2
+    exit 1
+  fi
+
+  if [ ! -f "$version_file" ]; then
+    echo "Version file not found: $version_file" >&2
+    exit 1
+  fi
+
+  temp_dir=$(mktemp -d)
+  trap "rm -rf -- '$temp_dir'" EXIT
+
+  layer_dir="$temp_dir/$artifact_name"
+  layer_tar="$temp_dir/${artifact_name}.tar.gz"
+  payload_basename=$(basename "$payload_file")
+
+  mkdir -p "$layer_dir/db" "$(dirname "$ref_file")"
+  cp "$payload_file" "$layer_dir/db/$payload_basename"
+  cp "$version_file" "$layer_dir/db/"
+
+  tar -czf "$layer_tar" -C "$layer_dir" db/
+
+  repository="${prefix}/${artifact_name}"
+  reference="${repository}:${version}"
+
+  crane append \
+    --new_layer "$layer_tar" \
+    --new_tag "$reference" \
+    --oci-empty-base
+
+  crane tag "$reference" latest
+
+  digest=$(crane digest "$reference")
+  latest_digest=$(crane digest "${repository}:latest")
+
+  if [ "$digest" != "$latest_digest" ]; then
+    echo "latest tag verification failed for ${artifact_name}" >&2
+    echo "Version digest: $digest" >&2
+    echo "Latest digest:  $latest_digest" >&2
+    exit 1
+  fi
+
+  full_reference="${repository}:${version}@${digest}"
+
+  printf '%s\n' "$full_reference" > "$ref_file"
+  echo "Published ${artifact_name} to: $full_reference"
+}
+
+download_artifact() {
+  local artifact_name=$1
+  local payload_file=$2
+  local destination_file=$3
+  local version=$4
+  local ref_file=${5:-$(default_ref_file "$artifact_name")}
+  local prefix
+  local reference
+  local temp_dir
+  local temp_tar
+
+  prefix=$(repo_prefix)
+  reference="${prefix}/${artifact_name}:${version}"
+
+  if [ -f "$ref_file" ]; then
+    reference=$(tr -d '\n' < "$ref_file")
+  fi
+
+  temp_dir=$(mktemp -d)
+  trap "rm -rf -- '$temp_dir'" EXIT
+  temp_tar="$temp_dir/${artifact_name}.tar"
+
+  mkdir -p "$(dirname "$destination_file")"
+
+  crane export "$reference" "$temp_tar"
+  tar -xf "$temp_tar" -C "$temp_dir"
+  cp "$temp_dir/db/$payload_file" "$destination_file"
+}
+
+main() {
+  if [ "$#" -lt 1 ]; then
+    usage >&2
+    exit 1
+  fi
+
+  case "$1" in
+    publish)
+      if [ "$#" -lt 5 ] || [ "$#" -gt 6 ]; then
+        usage >&2
+        exit 1
+      fi
+      shift
+      publish_artifact "$@"
+      ;;
+    download)
+      if [ "$#" -lt 5 ] || [ "$#" -gt 6 ]; then
+        usage >&2
+        exit 1
+      fi
+      shift
+      download_artifact "$@"
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Description
- Current  release scanner will fail because the new cvedb is in ghcr.io
## Solution
- adopt the changes in https://github.com/neuvector/release/pull/123/changes

